### PR TITLE
Add About page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# PallKitt
+# PallKit
+
+Applicazione di esempio per la gestione dei sintomi e l'identificazione dei bisogni in cure palliative.
+
+È disponibile una pagina [About](gestione-sintomi/about.php) con alcune informazioni generali sul progetto.

--- a/gestione-sintomi/about.php
+++ b/gestione-sintomi/about.php
@@ -1,0 +1,18 @@
+<?php
+// about.php
+?>
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <meta charset="UTF-8">
+  <title>Informazioni sul progetto</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="css/avada-compat.css" rel="stylesheet">
+</head>
+<body class="container py-5">
+  <h2>Informazioni su PallKit</h2>
+  <p>PallKit è un progetto sperimentale per la gestione dei sintomi e l'identificazione dei bisogni in ambito di cure palliative. Questa semplice dashboard vuole facilitare la pratica clinica quotidiana.</p>
+  <p>Il progetto è stato sviluppato a scopo dimostrativo e può essere liberamente adattato alle proprie necessità.</p>
+  <a href="index.php" class="btn btn-primary mt-3">Torna alla Dashboard</a>
+</body>
+</html>

--- a/gestione-sintomi/index.php
+++ b/gestione-sintomi/index.php
@@ -52,6 +52,11 @@
           <i class="fas fa-user-md me-2"></i>Dati Medico
         </a>
       </li>
+      <li class="nav-item mt-2">
+        <a href="about.php" class="nav-link">
+          <i class="fas fa-info-circle me-2"></i>About
+        </a>
+      </li>
     </ul>
   </nav>
 


### PR DESCRIPTION
## Summary
- add a simple About page with Bootstrap styling
- link to the new page from the sidebar
- clean up README and mention the new page

## Testing
- `ls`

------
https://chatgpt.com/codex/tasks/task_e_68691ea182948328ab86bc0ad6483ba6