### PR TITLE
Implement test data autofill for Dati Medico

### DIFF
--- a/gestione-sintomi/index.php
+++ b/gestione-sintomi/index.php
@@ -280,6 +280,10 @@
       </div>
       <div class="modal-body">
         <form id="form-medico" class="row g-3">
+          <div class="col-12 form-check">
+            <input class="form-check-input" type="checkbox" id="medico-use-test">
+            <label class="form-check-label" for="medico-use-test">Usa dati di test</label>
+          </div>
           <div class="col-md-3">
             <label class="form-label">Titolo</label>
             <select class="form-select" id="medico-titolo-select">

--- a/gestione-sintomi/js/app.js
+++ b/gestione-sintomi/js/app.js
@@ -244,6 +244,19 @@ document.addEventListener("DOMContentLoaded", function() {
     data:         ''
   };
 
+  const medicoTestData = {
+    titolo: 'Dott.',
+    nome: 'Mario Rossi',
+    studio: 'ASL Roma 1',
+    specializzazioni: ['Medico di medicina generale'],
+    codice: '123456',
+    indirizzi: ['via delle Rose 10 - Roma'],
+    telefoni: ['3331234567'],
+    mails: ['mario.rossi@example.com'],
+    luogo: 'Roma',
+    data: '2025-07-06'
+  };
+
   // Popola i campi della modale con i valori correnti quando viene aperta
   const medicoModal = document.getElementById('medico-modal-home');
   const titoloSelect = document.getElementById('medico-titolo-select');
@@ -252,6 +265,41 @@ document.addEventListener("DOMContentLoaded", function() {
   const indirizzoList = document.getElementById('indirizzo-list');
   const telList = document.getElementById('tel-list');
   const mailList = document.getElementById('mail-list');
+  const useTestCheckbox = document.getElementById('medico-use-test');
+
+  function setMedicoFormValues(data) {
+    const titoliPredef = ['Dott.','Dott.ssa','Prof.','Prof.ssa'];
+    if (data.titolo && titoliPredef.includes(data.titolo)) {
+      titoloSelect.value = data.titolo;
+      titoloCustom.value = '';
+    } else if (data.titolo) {
+      titoloSelect.value = 'custom';
+      titoloCustom.value = data.titolo;
+    } else {
+      titoloSelect.value = '';
+      titoloCustom.value = '';
+    }
+    updateTitoloVisibility();
+    document.getElementById('medico-nome-input').value   = data.nome || '';
+    document.getElementById('medico-studio-input').value = data.studio || '';
+    fillList(specList, data.specializzazioni || [], '.spec-input');
+    document.getElementById('medico-codice-input').value = data.codice || '';
+    fillList(indirizzoList, data.indirizzi || [], '.indirizzo-input');
+    fillList(telList, data.telefoni || [], '.tel-input');
+    fillList(mailList, data.mails || [], '.mail-input');
+    document.getElementById('medico-luogo-input').value  = data.luogo || '';
+    document.getElementById('medico-data-input').value   = data.data || '';
+  }
+
+  function toggleMedicoTestData() {
+    if (useTestCheckbox && useTestCheckbox.checked) {
+      setMedicoFormValues(medicoTestData);
+    } else {
+      setMedicoFormValues({titolo:'',nome:'',studio:'',specializzazioni:[],codice:'',indirizzi:[],telefoni:[],mails:[],luogo:'',data:''});
+    }
+  }
+
+  if (useTestCheckbox) useTestCheckbox.addEventListener('change', toggleMedicoTestData);
   function updateTitoloVisibility() {
     if (!titoloSelect) return;
     if (titoloSelect.value === 'custom') {
@@ -306,6 +354,7 @@ document.addEventListener("DOMContentLoaded", function() {
       fillList(mailList, medicoData.mails, '.mail-input');
       document.getElementById('medico-luogo-input').value = medicoData.luogo;
       document.getElementById('medico-data-input').value  = medicoData.data || new Date().toISOString().split('T')[0];
+      if (useTestCheckbox && useTestCheckbox.checked) toggleMedicoTestData();
     });
   }
   function saveMedicoHome() {


### PR DESCRIPTION
## Summary
- add a checkbox to enable test data in the Dati Medico modal
- implement logic in app.js to fill/clear the form when toggled

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686a76cce190832883b1feb7aad5c14c