### PR TITLE
Fix PDF spacing and style for doctor info

### DIFF
--- a/gestione-sintomi/css/avada-compat.css
+++ b/gestione-sintomi/css/avada-compat.css
@@ -135,6 +135,10 @@ p {
     display: flex;
     flex-direction: column;
 }
+.doc-container p {
+    margin-bottom: 0.25rem;
+    line-height: 1.2;
+}
 
 .doc-footer {
     margin-top: auto;

--- a/gestione-sintomi/css/avada-compat.css
+++ b/gestione-sintomi/css/avada-compat.css
@@ -128,6 +128,10 @@ p {
 }
 .header-left h6 {
     font-size: 1rem;
+    font-style: italic;
+    font-weight: normal !important;
+    margin-top: 0;
+    margin-bottom: 0.25rem;
 }
 
 .doc-container {

--- a/gestione-sintomi/js/app.js
+++ b/gestione-sintomi/js/app.js
@@ -390,6 +390,8 @@ function buildPreviewContent() {
   const h2 = document.createElement('h6');
   h2.textContent = 'Medico Chirurgo';
   h2.style.fontStyle = 'italic';
+  h2.style.fontWeight = 'normal';
+  h2.style.marginBottom = '0.25rem';
   h2.style.color = '#000';
   header.appendChild(h2);
   cont.appendChild(header);


### PR DESCRIPTION
## Summary
- reduce margin and line height of doctor details in PDF
- ensure "Medico Chirurgo" is italic only

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a78ff12e48328979fc450f7340900