### PR TITLE
Fix uniform stamp spacing in PDF export

### DIFF
--- a/gestione-sintomi/css/avada-compat.css
+++ b/gestione-sintomi/css/avada-compat.css
@@ -130,6 +130,13 @@ p {
     font-size: 1rem;
 }
 
+.doc-container h5,
+.doc-container h6 {
+    margin-top: 0;
+    margin-bottom: 0.25rem;
+    line-height: 1.3;
+}
+
 .doc-container {
     min-height: 100vh;
     display: flex;


### PR DESCRIPTION
## Summary
- normalize heading line spacing in document preview styles

## Testing
- `php -l gestione-sintomi/index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a8d70ceb48328a8029ee1cd30e98f