### PR TITLE
Move footer to bottom of exported PDF

### DIFF
--- a/gestione-sintomi/css/avada-compat.css
+++ b/gestione-sintomi/css/avada-compat.css
@@ -86,7 +86,8 @@ p {
 
 /* Stili per anteprima tabella riepilogo */
 .summary-table {
-    font-family: Calibri, sans-serif;
+    /* Usa Open Sans come font di base per l'anteprima e l'export */
+    font-family: 'Open Sans', Calibri, sans-serif;
     font-size: 11pt;
     border-collapse: collapse;
     width: 100%;
@@ -122,6 +123,7 @@ p {
 
 .header-left {
     text-align: left;
+    font-family: 'Open Sans', Arial, sans-serif;
 }
 .header-left h5 {
     font-size: 1.25rem;
@@ -136,6 +138,7 @@ p {
     min-height: 27cm; /* A4 height minus default pdf margins */
     display: flex;
     flex-direction: column;
+    font-family: 'Open Sans', Arial, sans-serif;
 }
 
 /* Riduce l'interlinea nei paragrafi del documento esportato */
@@ -146,6 +149,7 @@ p {
 
 .doc-footer {
     margin-top: auto;
+    font-family: 'Open Sans', Arial, sans-serif;
 }
 
 /* Aumenta dimensione e spaziatura del testo di chiusura */

--- a/gestione-sintomi/css/avada-compat.css
+++ b/gestione-sintomi/css/avada-compat.css
@@ -150,7 +150,7 @@ p {
 
 /* Aumenta dimensione e spaziatura del testo di chiusura */
 .doc-footer p {
-    font-size: 11pt;
+    font-size: 12pt;
 }
 
 .doc-footer p:first-child {

--- a/gestione-sintomi/css/avada-compat.css
+++ b/gestione-sintomi/css/avada-compat.css
@@ -131,9 +131,9 @@ p {
 }
 
 .doc-container {
-    /* Ensure enough vertical space so the footer can stick to the bottom
-       when exporting to PDF */
-    min-height: 29.7cm; /* approximate height of an A4 page */
+    /* Enough vertical space for the footer but short enough to avoid
+       spilling onto a second page when exporting to PDF with 0.5in margins */
+    min-height: 27cm; /* A4 height minus default pdf margins */
     display: flex;
     flex-direction: column;
 }

--- a/gestione-sintomi/css/avada-compat.css
+++ b/gestione-sintomi/css/avada-compat.css
@@ -131,7 +131,9 @@ p {
 }
 
 .doc-container {
-    min-height: 100vh;
+    /* Ensure enough vertical space so the footer can stick to the bottom
+       when exporting to PDF */
+    min-height: 29.7cm; /* approximate height of an A4 page */
     display: flex;
     flex-direction: column;
 }

--- a/gestione-sintomi/css/avada-compat.css
+++ b/gestione-sintomi/css/avada-compat.css
@@ -148,6 +148,15 @@ p {
     margin-top: auto;
 }
 
+/* Aumenta dimensione e spaziatura del testo di chiusura */
+.doc-footer p {
+    font-size: 11pt;
+}
+
+.doc-footer p:first-child {
+    margin-bottom: 0.75rem;
+}
+
 @media (max-width: 768px) {
     .sidebar {
         width: 100%;

--- a/gestione-sintomi/js/app.js
+++ b/gestione-sintomi/js/app.js
@@ -472,11 +472,32 @@ function showPreviewHome() {
     });
 
     const closing = [
-      new Paragraph({ text:'Cordiali saluti', spacing:{ before:400 } }),
-      new Paragraph({ text:`${medicoData.titolo} ${medicoData.nome}`.trim() })
+      new Paragraph({
+        text: 'Cordiali saluti',
+        spacing: { before: 400, after: 100 },
+        style: 'FooterText'
+      }),
+      new Paragraph({
+        text: `${medicoData.titolo} ${medicoData.nome}`.trim(),
+        style: 'FooterText'
+      })
     ];
 
-    const doc = new Document({ sections:[{ children: [...header, table, ...closing] }] });
+    const docStyles = {
+      paragraphStyles: [
+        {
+          id: 'FooterText',
+          name: 'FooterText',
+          run: { size: 22 },
+          paragraph: { spacing: { line: 360 } }
+        }
+      ]
+    };
+
+    const doc = new Document({
+      styles: docStyles,
+      sections: [{ children: [...header, table, ...closing] }]
+    });
     const blob = await Packer.toBlob(doc);
     saveAs(blob, 'riepilogo.docx');
   }

--- a/gestione-sintomi/js/app.js
+++ b/gestione-sintomi/js/app.js
@@ -488,7 +488,7 @@ function showPreviewHome() {
         {
           id: 'FooterText',
           name: 'FooterText',
-          run: { size: 22 },
+          run: { size: 24 },
           paragraph: { spacing: { line: 360 } }
         }
       ]


### PR DESCRIPTION
## Summary
- ensure footer sticks to the bottom of PDF export by giving the container a page-sized height

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a96c2a3308328803a1cd8705bd851