### PR TITLE
Adjust footer text size in Word export

### DIFF
--- a/gestione-sintomi/js/app.js
+++ b/gestione-sintomi/js/app.js
@@ -499,7 +499,7 @@ function showPreviewHome() {
         {
           id: 'FooterText',
           name: 'FooterText',
-          run: { size: 24 },
+          run: { size: 20 },
           paragraph: { spacing: { line: 360 } }
         }
       ]


### PR DESCRIPTION
## Summary
- tweak footer text style for smaller size in generated Word document

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ac6e00d588328a042c52ee10aa143