### PR TITLE
Add patient documents cards

### DIFF
--- a/gestione-sintomi/css/documents.css
+++ b/gestione-sintomi/css/documents.css
@@ -17,6 +17,19 @@
   position: relative;
   min-height: 170px;
 }
+.doc-card .delete-btn {
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  background: transparent;
+  border: none;
+  color: #888;
+  font-size: 1.2em;
+  cursor: pointer;
+}
+.doc-card .delete-btn:hover {
+  color: #c00;
+}
 .doc-card .doc-type {
   font-weight: bold;
   font-size: 1.1em;

--- a/gestione-sintomi/css/documents.css
+++ b/gestione-sintomi/css/documents.css
@@ -1,0 +1,64 @@
+.dashboard-cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  justify-content: flex-start;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+.doc-card {
+  background: #fff;
+  border-radius: 14px;
+  box-shadow: 0 3px 10px rgba(60,60,60,0.07);
+  width: 330px;
+  padding: 28px 24px 18px 24px;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  min-height: 170px;
+}
+.doc-card .doc-type {
+  font-weight: bold;
+  font-size: 1.1em;
+  color: #388e3c;
+  margin-bottom: 8px;
+  letter-spacing: 0.2px;
+}
+.doc-card .doc-date {
+  font-size: 0.97em;
+  color: #666;
+  margin-bottom: 12px;
+}
+.doc-card .doc-desc {
+  font-size: 1.05em;
+  color: #222;
+  flex-grow: 1;
+  margin-bottom: 18px;
+}
+.doc-card .card-actions {
+  display: flex;
+  gap: 10px;
+}
+.doc-card .card-actions button {
+  background: #4caf50;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 8px 18px;
+  font-size: 1em;
+  cursor: pointer;
+  transition: background 0.18s;
+}
+.doc-card .card-actions .pdf-btn {
+  background: #1976d2;
+}
+.doc-card .card-actions button:hover {
+  background: #2e7d32;
+}
+.doc-card .card-actions .pdf-btn:hover {
+  background: #135ba1;
+}
+@media (max-width: 900px) {
+  .dashboard-cards { flex-direction: column; gap: 20px; }
+  .doc-card { width: 97%; }
+}

--- a/gestione-sintomi/identificazione.php
+++ b/gestione-sintomi/identificazione.php
@@ -11,7 +11,7 @@
       <!-- Data compilazione -->
       <div class="mb-3">
         <label for="date-1" class="form-label">Data compilazione <span class="text-danger">*</span></label>
-        <input type="date" id="date-1" name="date_1" class="form-control" required>
+        <input type="date" id="date-1" name="date_1" class="form-control" required value="<?php echo date('Y-m-d'); ?>">
       </div>
 
       <!-- Nome e Cognome -->

--- a/gestione-sintomi/identificazione.php
+++ b/gestione-sintomi/identificazione.php
@@ -130,6 +130,14 @@
         </button>
       </div>
     </form>
+    <!-- Risultato salvataggio -->
+    <div id="necpal-result" class="mt-4" style="display:none;">
+      <div class="mb-2">
+        <button type="button" id="btn-view-necpal" class="btn btn-outline-secondary me-2">Visualizza</button>
+        <button type="button" id="btn-save-pdf" class="btn btn-success">Scarica PDF</button>
+      </div>
+      <div id="necpal-preview" class="mt-2" style="display:none;"></div>
+    </div>
   </div>
 </section>
 

--- a/gestione-sintomi/index.php
+++ b/gestione-sintomi/index.php
@@ -13,6 +13,8 @@
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.1/css/all.min.css" rel="stylesheet">
   <!-- Avada compatibility styles -->
   <link href="/css/avada-compat.css" rel="stylesheet">
+  <!-- Document cards styles -->
+  <link href="/css/documents.css" rel="stylesheet">
 </head>
 <body>
 
@@ -68,6 +70,9 @@
     <div id="dashboard-home" class="p-4">
       <h4>Benvenuto nella dashboard</h4>
       <p>Da qui puoi accedere a Gestione Sintomi o Identificazione.</p>
+
+      <h5 class="mt-4 mb-3">Documenti paziente</h5>
+      <div id="documenti-container" class="dashboard-cards"></div>
     </div>
 
     <!-- SEZIONE Gestione Sintomi -->
@@ -455,6 +460,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.9.2/html2pdf.bundle.min.js"></script>
 <script src="/js/sedazione.data.js"></script>
 <script src="/js/sedazione.js"></script>
+<script src="/js/documents.js"></script>
 <script>
   document.addEventListener('DOMContentLoaded', function () {
     const d = document.getElementById("today-date-home");

--- a/gestione-sintomi/js/app.js
+++ b/gestione-sintomi/js/app.js
@@ -618,27 +618,6 @@ if (exportPdfBtn) exportPdfBtn.addEventListener('click', exportPdfHome);
   }));
   document.querySelectorAll('.popup-indicatore .close-popup').forEach(b => b.addEventListener('click', () => b.closest('.popup-indicatore').style.display='none'));
   document.querySelectorAll('.popup-indicatore').forEach(ov => ov.addEventListener('click', e => { if (e.target===ov) ov.style.display='none'; }));
-// Genera PDF per la sezione Identificazione
-const savePdfBtn = document.getElementById('btn-save-pdf');
-if (savePdfBtn) {
-  savePdfBtn.addEventListener('click', () => {
-    // Seleziona l'intera sezione di Identificazione
-    const element = document.getElementById('identificazione-home');
-    if (!element) return alert('Sezione identificazione non trovata.');
-
-    // Opzioni PDF
-    const opt = {
-      margin:       0.5,               // margini in pollici
-      filename:     'identificazione.pdf',
-      image:        { type: 'jpeg', quality: 0.98 },
-      html2canvas:  { scale: 2 },       // migliore risoluzione
-      jsPDF:        { unit: 'in', format: 'a4', orientation: 'portrait' }
-    };
-
-    // Genera e avvia il download
-    html2pdf().set(opt).from(element).save();
-  });
-}
 
   // ──────────────────────────────
   // 9) EQUIANALGESIA

--- a/gestione-sintomi/js/documents.js
+++ b/gestione-sintomi/js/documents.js
@@ -36,22 +36,45 @@ document.addEventListener('DOMContentLoaded', function () {
     render();
   };
 
+  function pdfFromHtml(html, filename) {
+    const tmp = document.createElement('div');
+    tmp.innerHTML = html;
+    const opt = {
+      margin: 0.5,
+      filename: filename,
+      image: { type: 'jpeg', quality: 0.98 },
+      html2canvas: { scale: 2 },
+      jsPDF: { unit: 'in', format: 'a4', orientation: 'portrait' }
+    };
+    html2pdf().set(opt).from(tmp).save();
+  }
+
   function downloadDoc(doc) {
     switch(doc.type) {
       case 'riepilogo':
         if (window.exportPdfHome) window.exportPdfHome();
         break;
       case 'necpal':
-        if (window.downloadNecpalPdf) window.downloadNecpalPdf();
+        if (doc.html) pdfFromHtml(doc.html, 'NECPAL.pdf');
+        else if (window.downloadNecpalPdf) window.downloadNecpalPdf();
         break;
       default:
         alert('Download non disponibile');
     }
   }
 
+  function showDoc(doc) {
+    if (!doc.html) return alert('Anteprima non disponibile.');
+    const modalBody = document.getElementById('preview-content-home');
+    if (!modalBody) return alert('Anteprima non disponibile.');
+    modalBody.innerHTML = doc.html;
+    new bootstrap.Modal(document.getElementById('preview-modal-home')).show();
+  }
+
   container.addEventListener('click', function(e) {
     if (e.target.classList.contains('view-btn')) {
-      alert('Anteprima non disponibile.');
+      const doc = patientDocs[e.target.dataset.index];
+      if (doc) showDoc(doc);
     } else if (e.target.classList.contains('pdf-btn')) {
       const doc = patientDocs[e.target.dataset.index];
       if (doc) downloadDoc(doc);
@@ -63,16 +86,18 @@ document.addEventListener('DOMContentLoaded', function () {
 
 // Funzione per scaricare nuovamente il PDF NECPAL
 function downloadNecpalPdf() {
-  const element = document.getElementById('identificazione-home');
-  if (!element) return alert('Sezione identificazione non trovata.');
+  const preview = document.getElementById('necpal-preview');
+  if (!preview || !preview.innerHTML.trim()) return alert('Anteprima non disponibile.');
+  const tmp = document.createElement('div');
+  tmp.innerHTML = preview.innerHTML;
   const opt = {
     margin: 0.5,
-    filename: 'identificazione.pdf',
+    filename: 'NECPAL.pdf',
     image: { type: 'jpeg', quality: 0.98 },
     html2canvas: { scale: 2 },
     jsPDF: { unit: 'in', format: 'a4', orientation: 'portrait' }
   };
-  html2pdf().set(opt).from(element).save();
+  html2pdf().set(opt).from(tmp).save();
 }
 window.downloadNecpalPdf = downloadNecpalPdf;
 
@@ -99,14 +124,43 @@ document.addEventListener('DOMContentLoaded', function () {
   const previewBox = document.getElementById('necpal-preview');
   const viewBtn = document.getElementById('btn-view-necpal');
 
-  function buildNecpalPreview(fd) {
-    const q = fd.get('radio_1') === 'one' ? 'Sì' : 'No';
+  function buildNecpalHtml(fd) {
+    const date1 = fd.get('date_1');
+    const name  = fd.get('text_1');
+    const dob   = fd.get('date_2');
+    const q     = fd.get('radio_1');
+    const cb1   = fd.get('checkbox_1') ? true : false;
+    const cb2   = fd.get('checkbox_2') ? true : false;
+    const cb3   = fd.getAll('checkbox_3[]');
+    const cb4   = fd.getAll('checkbox_4[]');
+    const items = [];
+    items.push(['Scelta/Richiesta approccio palliativo', cb1]);
+    items.push(['Bisogni identificati dai sanitari', cb2]);
+    cb3.forEach(t => items.push([t, true]));
+    cb4.forEach(t => items.push([t, true]));
+    const rows = items.map((it, i) => {
+      const bg = i % 2 ? '#f2f2f2' : '#ffffff';
+      return `<tr style="background:${bg};">
+                <td style="width:40px;text-align:center;border:1px solid #ccc;">${it[1] ? 'X' : ''}</td>
+                <td style="border:1px solid #ccc;padding:4px 6px;">${it[0]}</td>
+              </tr>`;
+    }).join('');
+    const positive = q === 'two' && items.some(i => i[1]) ? 'POSITIVO' : 'NEGATIVO';
     return `
-      <div class="card card-body">
-        <p><strong>Data compilazione:</strong> ${fd.get('date_1')}</p>
-        <p><strong>Nome e Cognome:</strong> ${fd.get('text_1')}</p>
-        <p><strong>Data di nascita:</strong> ${fd.get('date_2')}</p>
-        <p><strong>Surprise question:</strong> ${q}</p>
+      <div style="font-family: Helvetica, Arial, sans-serif; font-size:11pt;">
+        <div style="background:#e0e0e0; padding:6px; text-align:center; font-weight:bold;">
+          Ambulatorio MMG – Dr. Francesco Magnante
+        </div>
+        <div style="background:#f7f7f7; padding:8px; margin-top:10px;">
+          <strong>Nome paziente:</strong> ${name}<br>
+          <strong>Data di nascita:</strong> ${dob}<br>
+          <strong>Data di compilazione:</strong> ${date1}
+        </div>
+        <h4 style="background:#e0e0e0; padding:4px; margin-top:20px; font-size:1rem;">Item NECPAL</h4>
+        <table style="width:100%; border-collapse:collapse; font-size:11pt;">${rows}</table>
+        <div style="background:#cccccc; padding:6px; margin-top:20px; font-weight:bold;">
+          Esito finale: ${positive}
+        </div>
       </div>`;
   }
 
@@ -119,16 +173,18 @@ document.addEventListener('DOMContentLoaded', function () {
         .then(r => r.ok ? r.json() : Promise.reject())
         .then(res => {
           if (res.success) {
+            const html = buildNecpalHtml(fd);
             if (resultBox) resultBox.style.display = 'block';
             if (previewBox) {
-              previewBox.innerHTML = buildNecpalPreview(fd);
+              previewBox.innerHTML = html;
               previewBox.style.display = 'block';
             }
             addPatientDoc({
               title: 'NECPAL',
               date: new Date().toLocaleDateString('it-IT'),
-              desc: 'Score NEC PAL completo',
-              type: 'necpal'
+              desc: 'Score NECPAL completo',
+              type: 'necpal',
+              html: html
             });
           } else {
             alert('Errore durante il salvataggio');

--- a/gestione-sintomi/js/documents.js
+++ b/gestione-sintomi/js/documents.js
@@ -1,11 +1,7 @@
 // documents.js
 // Gestione dinamica dei documenti del paziente
 
-document.addEventListener('DOMContentLoaded', function () {
-  const container = document.getElementById('documenti-container');
-  if (!container) return;
-
-  const CLINICI = [
+const CLINICI = [
     "Perdita di peso > 10%",
     "Declino funzionale: Australian Karnofsky riduzione > 30%",
     "Declino funzionale: ADL riduzione > 2 funzioni",
@@ -20,7 +16,7 @@ document.addEventListener('DOMContentLoaded', function () {
     "Utilizzo risorse: Aumento domanda/interventi"
   ];
 
-  const SPECIFICI = [
+const SPECIFICI = [
     "Cancro",
     "Patologie polmonari croniche",
     "Patologie cardiache croniche",
@@ -31,6 +27,10 @@ document.addEventListener('DOMContentLoaded', function () {
     "Patologie epatiche croniche",
     "Patologia renale cronica"
   ];
+
+document.addEventListener('DOMContentLoaded', function () {
+  const container = document.getElementById('documenti-container');
+  if (!container) return;
 
   window.patientDocs = [];
 

--- a/gestione-sintomi/js/documents.js
+++ b/gestione-sintomi/js/documents.js
@@ -209,7 +209,8 @@ document.addEventListener('DOMContentLoaded', function () {
       e.preventDefault();
       const fd = new FormData(necpalForm);
       fd.append('ajax', '1');
-      fetch('process-necpal.php', { method: 'POST', body: fd })
+      const url = necpalForm.getAttribute('action') || 'process-necpal.php';
+      fetch(url, { method: 'POST', body: fd })
         .then(r => r.ok ? r.json() : Promise.reject())
         .then(res => {
           if (res.success) {
@@ -227,10 +228,14 @@ document.addEventListener('DOMContentLoaded', function () {
               html: html
             });
           } else {
-            alert('Errore durante il salvataggio');
+            const msg = res.errors ? res.errors.join('\n') : (res.error || 'Errore durante il salvataggio');
+            alert(msg);
           }
         })
-        .catch(() => alert('Errore durante il salvataggio'));
+        .catch(err => {
+          alert('Errore durante il salvataggio');
+          console.error('NECPAL save error', err);
+        });
     });
   }
 

--- a/gestione-sintomi/js/documents.js
+++ b/gestione-sintomi/js/documents.js
@@ -5,6 +5,33 @@ document.addEventListener('DOMContentLoaded', function () {
   const container = document.getElementById('documenti-container');
   if (!container) return;
 
+  const CLINICI = [
+    "Perdita di peso > 10%",
+    "Declino funzionale: Australian Karnofsky riduzione > 30%",
+    "Declino funzionale: ADL riduzione > 2 funzioni",
+    "Declino cognitivo: Perdita ≥ 5 punti MMSE",
+    "Dipendenza grave: Australian Karnofsky (AKPS) < 50",
+    "Sindromi geriatriche ≥ 2 (cadute, disfagia, delirium, ulcere da decubito, infezioni)",
+    "Sintomi persistenti: Dolore, Astenia, Anoressia o ESAS/IPOS ≥ 2 sintomi",
+    "Aspetti psico-sociali: DME > 9 o 2 items IPOS ≥ 3",
+    "Vulnerabilità sociale grave (valutazione sociale/familiare)",
+    "Comorbidità > 2 malattie croniche",
+    "Utilizzo risorse: > 2 ricoveri urgenti/non pianificati ultimi 6 mesi",
+    "Utilizzo risorse: Aumento domanda/interventi"
+  ];
+
+  const SPECIFICI = [
+    "Cancro",
+    "Patologie polmonari croniche",
+    "Patologie cardiache croniche",
+    "Demenza",
+    "Fragilità",
+    "Patologie neurovascolari croniche (ictus)",
+    "Patologie neurologiche croniche: SM/SLA/Parkinson",
+    "Patologie epatiche croniche",
+    "Patologia renale cronica"
+  ];
+
   window.patientDocs = [];
 
   function render() {
@@ -20,6 +47,7 @@ document.addEventListener('DOMContentLoaded', function () {
       const card = document.createElement('div');
       card.className = 'doc-card';
       card.innerHTML = `
+        <button class="delete-btn" data-index="${idx}">&times;</button>
         <div class="doc-type">${doc.title}</div>
         <div class="doc-date">${doc.date}</div>
         <div class="doc-desc">${doc.desc}</div>
@@ -78,6 +106,14 @@ document.addEventListener('DOMContentLoaded', function () {
     } else if (e.target.classList.contains('pdf-btn')) {
       const doc = patientDocs[e.target.dataset.index];
       if (doc) downloadDoc(doc);
+    } else if (e.target.classList.contains('delete-btn')) {
+      const idx = parseInt(e.target.dataset.index, 10);
+      if (!isNaN(idx)) {
+        if (confirm('Eliminare il documento?')) {
+          patientDocs.splice(idx, 1);
+          render();
+        }
+      }
     }
   });
 
@@ -131,13 +167,13 @@ document.addEventListener('DOMContentLoaded', function () {
     const q     = fd.get('radio_1');
     const cb1   = fd.get('checkbox_1') ? true : false;
     const cb2   = fd.get('checkbox_2') ? true : false;
-    const cb3   = fd.getAll('checkbox_3[]');
-    const cb4   = fd.getAll('checkbox_4[]');
+    const cb3Sel = new Set(fd.getAll('checkbox_3[]'));
+    const cb4Sel = new Set(fd.getAll('checkbox_4[]'));
     const items = [];
     items.push(['Scelta/Richiesta approccio palliativo', cb1]);
     items.push(['Bisogni identificati dai sanitari', cb2]);
-    cb3.forEach(t => items.push([t, true]));
-    cb4.forEach(t => items.push([t, true]));
+    CLINICI.forEach(l => items.push([l, cb3Sel.has(l)]));
+    SPECIFICI.forEach(l => items.push([l, cb4Sel.has(l)]));
     const rows = items.map((it, i) => {
       const bg = i % 2 ? '#f2f2f2' : '#ffffff';
       return `<tr style="background:${bg};">
@@ -146,11 +182,15 @@ document.addEventListener('DOMContentLoaded', function () {
               </tr>`;
     }).join('');
     const positive = q === 'two' && items.some(i => i[1]) ? 'POSITIVO' : 'NEGATIVO';
+    const medicoName = (window.medicoData && (medicoData.nome || medicoData.titolo))
+      ? `${medicoData.titolo || ''} ${medicoData.nome || ''}`.trim()
+      : '';
+    const header = medicoName ?
+        `<div style="background:#e0e0e0; padding:6px; text-align:center; font-weight:bold;">Ambulatorio MMG – ${medicoName}</div>`
+        : '';
     return `
       <div style="font-family: Helvetica, Arial, sans-serif; font-size:11pt;">
-        <div style="background:#e0e0e0; padding:6px; text-align:center; font-weight:bold;">
-          Ambulatorio MMG – Dr. Francesco Magnante
-        </div>
+        ${header}
         <div style="background:#f7f7f7; padding:8px; margin-top:10px;">
           <strong>Nome paziente:</strong> ${name}<br>
           <strong>Data di nascita:</strong> ${dob}<br>

--- a/gestione-sintomi/js/documents.js
+++ b/gestione-sintomi/js/documents.js
@@ -1,0 +1,103 @@
+// documents.js
+// Gestione dinamica dei documenti del paziente
+
+document.addEventListener('DOMContentLoaded', function () {
+  const container = document.getElementById('documenti-container');
+  if (!container) return;
+
+  window.patientDocs = [];
+
+  function render() {
+    container.innerHTML = '';
+    if (patientDocs.length === 0) {
+      const p = document.createElement('p');
+      p.className = 'text-muted';
+      p.textContent = 'Nessun documento disponibile.';
+      container.appendChild(p);
+      return;
+    }
+    patientDocs.forEach((doc, idx) => {
+      const card = document.createElement('div');
+      card.className = 'doc-card';
+      card.innerHTML = `
+        <div class="doc-type">${doc.title}</div>
+        <div class="doc-date">${doc.date}</div>
+        <div class="doc-desc">${doc.desc}</div>
+        <div class="card-actions">
+          <button class="view-btn" data-index="${idx}">Visualizza</button>
+          <button class="pdf-btn" data-index="${idx}">Scarica PDF</button>
+        </div>`;
+      container.appendChild(card);
+    });
+  }
+
+  window.addPatientDoc = function(doc) {
+    patientDocs.push(doc);
+    render();
+  };
+
+  function downloadDoc(doc) {
+    switch(doc.type) {
+      case 'riepilogo':
+        if (window.exportPdfHome) window.exportPdfHome();
+        break;
+      case 'necpal':
+        if (window.downloadNecpalPdf) window.downloadNecpalPdf();
+        break;
+      default:
+        alert('Download non disponibile');
+    }
+  }
+
+  container.addEventListener('click', function(e) {
+    if (e.target.classList.contains('view-btn')) {
+      alert('Anteprima non disponibile.');
+    } else if (e.target.classList.contains('pdf-btn')) {
+      const doc = patientDocs[e.target.dataset.index];
+      if (doc) downloadDoc(doc);
+    }
+  });
+
+  render();
+});
+
+// Funzione per scaricare nuovamente il PDF NECPAL
+function downloadNecpalPdf() {
+  const element = document.getElementById('identificazione-home');
+  if (!element) return alert('Sezione identificazione non trovata.');
+  const opt = {
+    margin: 0.5,
+    filename: 'identificazione.pdf',
+    image: { type: 'jpeg', quality: 0.98 },
+    html2canvas: { scale: 2 },
+    jsPDF: { unit: 'in', format: 'a4', orientation: 'portrait' }
+  };
+  html2pdf().set(opt).from(element).save();
+}
+window.downloadNecpalPdf = downloadNecpalPdf;
+
+document.addEventListener('DOMContentLoaded', function () {
+  const exportPdfBtn = document.getElementById('btn-export-pdf-home');
+  if (exportPdfBtn) {
+    exportPdfBtn.addEventListener('click', () => {
+      addPatientDoc({
+        title: 'Riepilogo farmaci',
+        date: new Date().toLocaleDateString('it-IT'),
+        desc: 'Farmaci sintomatici attuali',
+        type: 'riepilogo'
+      });
+    });
+  }
+
+  const savePdfBtn = document.getElementById('btn-save-pdf');
+  if (savePdfBtn) {
+    savePdfBtn.addEventListener('click', () => {
+      addPatientDoc({
+        title: 'NECPAL',
+        date: new Date().toLocaleDateString('it-IT'),
+        desc: 'Score NEC PAL completo',
+        type: 'necpal'
+      });
+    });
+  }
+});

--- a/gestione-sintomi/js/documents.js
+++ b/gestione-sintomi/js/documents.js
@@ -91,13 +91,56 @@ document.addEventListener('DOMContentLoaded', function () {
 
   const savePdfBtn = document.getElementById('btn-save-pdf');
   if (savePdfBtn) {
-    savePdfBtn.addEventListener('click', () => {
-      addPatientDoc({
-        title: 'NECPAL',
-        date: new Date().toLocaleDateString('it-IT'),
-        desc: 'Score NEC PAL completo',
-        type: 'necpal'
-      });
+    savePdfBtn.addEventListener('click', downloadNecpalPdf);
+  }
+
+  const necpalForm = document.getElementById('necpal-form');
+  const resultBox = document.getElementById('necpal-result');
+  const previewBox = document.getElementById('necpal-preview');
+  const viewBtn = document.getElementById('btn-view-necpal');
+
+  function buildNecpalPreview(fd) {
+    const q = fd.get('radio_1') === 'one' ? 'Sì' : 'No';
+    return `
+      <div class="card card-body">
+        <p><strong>Data compilazione:</strong> ${fd.get('date_1')}</p>
+        <p><strong>Nome e Cognome:</strong> ${fd.get('text_1')}</p>
+        <p><strong>Data di nascita:</strong> ${fd.get('date_2')}</p>
+        <p><strong>Surprise question:</strong> ${q}</p>
+      </div>`;
+  }
+
+  if (necpalForm) {
+    necpalForm.addEventListener('submit', function(e) {
+      e.preventDefault();
+      const fd = new FormData(necpalForm);
+      fd.append('ajax', '1');
+      fetch('process-necpal.php', { method: 'POST', body: fd })
+        .then(r => r.ok ? r.json() : Promise.reject())
+        .then(res => {
+          if (res.success) {
+            if (resultBox) resultBox.style.display = 'block';
+            if (previewBox) {
+              previewBox.innerHTML = buildNecpalPreview(fd);
+              previewBox.style.display = 'block';
+            }
+            addPatientDoc({
+              title: 'NECPAL',
+              date: new Date().toLocaleDateString('it-IT'),
+              desc: 'Score NEC PAL completo',
+              type: 'necpal'
+            });
+          } else {
+            alert('Errore durante il salvataggio');
+          }
+        })
+        .catch(() => alert('Errore durante il salvataggio'));
+    });
+  }
+
+  if (viewBtn && previewBox) {
+    viewBtn.addEventListener('click', () => {
+      previewBox.style.display = previewBox.style.display === 'none' ? 'block' : 'none';
     });
   }
 });

--- a/gestione-sintomi/process-necpal.php
+++ b/gestione-sintomi/process-necpal.php
@@ -32,12 +32,20 @@ if (!in_array($radio1, ['one','two'], true)) {
     $errors[] = 'Risposta sorprendere non valida';
 }
 
+$isAjax = isset($_POST['ajax']) ||
+    (!empty($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest');
+
 if ($errors) {
-    echo "<h3>Errore:</h3><ul>";
-    foreach ($errors as $e) {
-        echo "<li>" . sanitize($e) . "</li>";
+    if ($isAjax) {
+        header('Content-Type: application/json');
+        echo json_encode(['success' => false, 'errors' => $errors]);
+    } else {
+        echo "<h3>Errore:</h3><ul>";
+        foreach ($errors as $e) {
+            echo "<li>" . sanitize($e) . "</li>";
+        }
+        echo "</ul><p><a href=\"index.php\">Torna indietro</a></p>";
     }
-    echo "</ul><p><a href=\"index.php\">Torna indietro</a></p>";
     exit;
 }
 
@@ -67,11 +75,20 @@ try {
         ':specifici' => $indicatori_specifici,
     ]);
 
-    // Redirect alla pagina di ringraziamento
-    header('Location: grazie.php');
+    if ($isAjax) {
+        header('Content-Type: application/json');
+        echo json_encode(['success' => true]);
+    } else {
+        header('Location: grazie.php');
+    }
     exit;
 
 } catch (PDOException $ex) {
-    echo "<h3>Errore server:</h3><p>" . sanitize($ex->getMessage()) . "</p>";
+    if ($isAjax) {
+        header('Content-Type: application/json');
+        echo json_encode(['success' => false, 'error' => $ex->getMessage()]);
+    } else {
+        echo "<h3>Errore server:</h3><p>" . sanitize($ex->getMessage()) . "</p>";
+    }
     exit;
 }


### PR DESCRIPTION
## Summary
- add dynamic patient document cards on dashboard
- style cards with modern responsive layout
- log NECPAL and riepilogo pdf exports as patient documents
- include helper JS for managing cards

## Testing
- `php -l gestione-sintomi/index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c2929b7908328938679e990dd435f