### PR TITLE
Rimuovi monitoraggio grafico IPOS e aggiungi compilazione di test

### DIFF
--- a/gestione-sintomi/js/app.js
+++ b/gestione-sintomi/js/app.js
@@ -485,12 +485,16 @@ document.addEventListener("DOMContentLoaded", function() {
   const nascIdc = document.getElementById('idcpal-nascita');
   if (nameIdc) nameIdc.value = pazienteData.nome || '';
   if (nascIdc) nascIdc.value = pazienteData.dataNascita || '';
+  const testIpos = document.getElementById('ipos-test');
   const nameIpos = document.getElementById('ipos-nome');
   const nascIpos = document.getElementById('ipos-nascita');
   const cfIpos   = document.getElementById('ipos-id');
-  if (nameIpos) nameIpos.value = pazienteData.nome || '';
-  if (nascIpos) nascIpos.value = pazienteData.dataNascita || '';
-  if (cfIpos)   cfIpos.value   = pazienteData.codFiscale || '';
+  const isTest   = testIpos && testIpos.checked;
+  if (!isTest) {
+    if (nameIpos) nameIpos.value = pazienteData.nome || '';
+    if (nascIpos) nascIpos.value = pazienteData.dataNascita || '';
+    if (cfIpos)   cfIpos.value   = pazienteData.codFiscale || '';
+  }
 }
   updatePazienteFields();
 

--- a/gestione-sintomi/js/ipos.js
+++ b/gestione-sintomi/js/ipos.js
@@ -5,6 +5,7 @@
     const form        = document.getElementById('ipos-form');
     const riepilogo   = document.getElementById('ipos-riepilogo');
     const summaryBox  = document.getElementById('ipos-summary');
+    const testBox     = document.getElementById('ipos-test');
 
     function updateTexts(){
       const days = intervallo.value === '3' ? 'negli ultimi 3 giorni' : 'nell\'ultima settimana';
@@ -41,6 +42,34 @@
         summaryBox.innerHTML = html;
         riepilogo.style.display = 'block';
         window.scrollTo({top: riepilogo.offsetTop-20, behavior:'smooth'});
+      });
+    }
+
+    function fillTest(){
+      const today = new Date().toISOString().slice(0,10);
+      document.getElementById('ipos-nome').value = 'Mario Rossi';
+      document.getElementById('ipos-nascita').value = '1970-01-01';
+      document.getElementById('ipos-data').value = today;
+      document.getElementById('ipos-id').value = 'TEST';
+      compilatore.value = 'paziente';
+      intervallo.value = '3';
+      form.querySelectorAll('textarea').forEach(t=>{t.value = 'Test';});
+      form.querySelectorAll('input[type=radio]').forEach(r=>{
+        if(r.value === '0') r.checked = true;
+      });
+      const q10 = form.querySelector('input[name="q10"][value="solo"]');
+      if(q10) q10.checked = true;
+      updateTexts();
+    }
+
+    if(testBox){
+      testBox.addEventListener('change', function(){
+        if(this.checked){
+          fillTest();
+        }else{
+          form.reset();
+          updateTexts();
+        }
       });
     }
   });

--- a/gestione-sintomi/process-ipos.php
+++ b/gestione-sintomi/process-ipos.php
@@ -84,6 +84,16 @@ foreach ($nums as $n) {
     if ($val >=0 && $val <=4) $punteggio += $val;
 }
 
+if ($idpaz === 'TEST') {
+    if ($isAjax) {
+        header('Content-Type: application/json');
+        echo json_encode(['success' => true]);
+    } else {
+        header('Location: grazie.php');
+    }
+    exit;
+}
+
 try {
     $pdo = getPDO();
     ensureTable($pdo);

--- a/gestione-sintomi/strumenti-ipos.php
+++ b/gestione-sintomi/strumenti-ipos.php
@@ -6,6 +6,10 @@
     <a href="#" class="small text-decoration-underline float-end" data-bs-toggle="modal" data-bs-target="#guida-ipos-modal">Guida alla compilazione</a>
     <hr>
     <form id="ipos-form" action="process-ipos.php" method="post">
+      <div class="form-check form-switch mb-3">
+        <input class="form-check-input" type="checkbox" id="ipos-test">
+        <label class="form-check-label" for="ipos-test">Compilazione di test</label>
+      </div>
       <div class="row g-3 mb-3">
         <div class="col-md-4">
           <label class="form-label">Nome e Cognome</label>
@@ -212,7 +216,6 @@ if($rows): ?>
       </table>
     </div>
 <?php endif; ?>
-    <canvas id="ipos-chart" height="200"></canvas>
     <div class="modal fade" id="guida-ipos-modal" tabindex="-1">
       <div class="modal-dialog modal-lg">
         <div class="modal-content">
@@ -234,15 +237,4 @@ if($rows): ?>
     </div>
   </div>
 </section>
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="js/ipos.js"></script>
-<script>
-(function(){
-  const data = <?php echo json_encode($rows ?? []); ?>;
-  if(!data.length) return;
-  const ctx = document.getElementById('ipos-chart').getContext('2d');
-  const labels = data.map(r=>r.data_compilazione);
-  const scores = data.map(r=>parseInt(r.punteggio_totale,10));
-  new Chart(ctx,{type:'line',data:{labels:labels,datasets:[{label:'Punteggio IPOS',data:scores,fill:false,borderColor:'blue'}]}});
-})();
-</script>

--- a/gestione-sintomi/strumenti-ipos.php
+++ b/gestione-sintomi/strumenti-ipos.php
@@ -199,7 +199,8 @@ $scale=[0,1,2,3,4];
 require_once __DIR__ . '/config.php';
 try {
   $pdo = getPDO();
-  $stmt = $pdo->query("SELECT * FROM ipos_submissions ORDER BY data_compilazione DESC");
+  $stmt = $pdo->prepare("SELECT * FROM ipos_submissions WHERE id_paziente <> 'TEST' ORDER BY data_compilazione DESC");
+  $stmt->execute();
   $rows = $stmt->fetchAll();
 } catch (Exception $e) {
   $rows = [];


### PR DESCRIPTION
## Cosa è stato fatto
- Rimossa la visualizzazione grafica del punteggio IPOS.
- Aggiunta una casella di controllo per compilare automaticamente il questionario in modalità test.

## Come testare
- `php -l gestione-sintomi/strumenti-ipos.php`


------
https://chatgpt.com/codex/tasks/task_e_688e41daf3d08328bd8f965d8fab6598