### PR TITLE
Ristruttura menu strumenti e aggiunge pagina prognosi

### DIFF
--- a/gestione-sintomi/index.php
+++ b/gestione-sintomi/index.php
@@ -57,17 +57,17 @@
       </li>
 
       <li class="nav-item mb-2">
-        <span class="nav-link text-white-50">Strumenti Clinici</span>
+        <span class="nav-link text-white-50"><i class="fas fa-chart-bar me-2"></i>Strumenti di Valutazione</span>
       </li>
 
       <li class="nav-item mb-2">
         <a class="nav-link submenu-toggle collapsed" data-bs-toggle="collapse" data-bs-target="#submenu-ident" href="#" role="button" aria-expanded="false">
-          <i class="fas fa-id-card me-2"></i>Identificazione
+          <i class="fas fa-search me-2"></i>Identificazione
           <i class="fas fa-chevron-right rotate-icon ms-auto"></i>
         </a>
         <ul class="nav flex-column collapse" id="submenu-ident" data-bs-parent="#clinical-menu">
           <li class="nav-item">
-            <a href="#" class="nav-link ms-3" data-target="identificazione-home">NECPAL 3.0</a>
+            <a href="#" class="nav-link ms-3" data-target="identificazione-home">NECPAL 3.1</a>
           </li>
           <li class="nav-item">
             <a href="#" class="nav-link ms-3" data-target="necpal4-home">NECPAL 4.0</a>
@@ -80,36 +80,12 @@
 
       <li class="nav-item mb-2">
         <a class="nav-link submenu-toggle collapsed" data-bs-toggle="collapse" data-bs-target="#submenu-compl" href="#" role="button" aria-expanded="false">
-          <i class="fas fa-layer-group me-2"></i>Complessità
+          <i class="fas fa-brain me-2"></i>Complessità
           <i class="fas fa-chevron-right rotate-icon ms-auto"></i>
         </a>
         <ul class="nav flex-column collapse" id="submenu-compl" data-bs-parent="#clinical-menu">
           <li class="nav-item">
             <a href="#" class="nav-link ms-3" data-target="idcpal-home">IDC-PAL</a>
-          </li>
-        </ul>
-      </li>
-
-      <li class="nav-item mb-2">
-        <a class="nav-link submenu-toggle collapsed" data-bs-toggle="collapse" data-bs-target="#submenu-prog" href="#" role="button" aria-expanded="false">
-          <i class="fas fa-hourglass-half me-2"></i>Prognosi
-          <i class="fas fa-chevron-right rotate-icon ms-auto"></i>
-        </a>
-        <ul class="nav flex-column collapse" id="submenu-prog" data-bs-parent="#clinical-menu">
-          <li class="nav-item">
-            <a href="#" class="nav-link ms-3" data-target="ppi-home">PPI</a>
-          </li>
-        </ul>
-      </li>
-
-      <li class="nav-item mb-2">
-        <a class="nav-link submenu-toggle collapsed" data-bs-toggle="collapse" data-bs-target="#submenu-monit" href="#" role="button" aria-expanded="false">
-          <i class="fas fa-chart-line me-2"></i>Monitoraggio
-          <i class="fas fa-chevron-right rotate-icon ms-auto"></i>
-        </a>
-        <ul class="nav flex-column collapse" id="submenu-monit" data-bs-parent="#clinical-menu">
-          <li class="nav-item">
-            <a href="#" class="nav-link ms-3" data-target="ipos-home">IPOS</a>
           </li>
         </ul>
       </li>
@@ -124,6 +100,71 @@
           <li class="nav-item"><a href="#" class="nav-link ms-3" onclick="openPerfModal('pps');">PPS</a></li>
           <li class="nav-item"><a href="#" class="nav-link ms-3" onclick="openPerfModal('adl');">ADL</a></li>
           <li class="nav-item"><a href="#" class="nav-link ms-3" onclick="openPerfModal('badl');">BADL</a></li>
+        </ul>
+      </li>
+
+      <li class="nav-item mb-2">
+        <a class="nav-link submenu-toggle collapsed" data-bs-toggle="collapse" data-bs-target="#submenu-prog" href="#" role="button" aria-expanded="false">
+          <i class="fas fa-chart-line me-2"></i>Prognosi
+          <i class="fas fa-chevron-right rotate-icon ms-auto"></i>
+        </a>
+        <ul class="nav flex-column collapse" id="submenu-prog" data-bs-parent="#clinical-menu">
+          <li class="nav-item"><a href="strumenti-prognosi.php?scale=ppi" class="nav-link ms-3">PPI</a></li>
+          <li class="nav-item"><a href="strumenti-prognosi.php?scale=pap" class="nav-link ms-3">PaP Score</a></li>
+        </ul>
+      </li>
+
+      <li class="nav-item mb-2">
+        <a class="nav-link submenu-toggle collapsed" data-bs-toggle="collapse" data-bs-target="#submenu-multi" href="#" role="button" aria-expanded="false">
+          <i class="fas fa-clipboard me-2"></i>Multidimensionale
+          <i class="fas fa-chevron-right rotate-icon ms-auto"></i>
+        </a>
+        <ul class="nav flex-column collapse" id="submenu-multi" data-bs-parent="#clinical-menu">
+          <li class="nav-item"><a href="#" class="nav-link ms-3" data-target="ipos-home">IPOS</a></li>
+          <li class="nav-item"><a href="#" class="nav-link ms-3" data-target="esas-home">ESAS</a></li>
+        </ul>
+      </li>
+
+      <li class="nav-item mb-2">
+        <a class="nav-link submenu-toggle collapsed" data-bs-toggle="collapse" data-bs-target="#submenu-dolore" href="#" role="button" aria-expanded="false">
+          <i class="fas fa-face-frown me-2"></i>Dolore
+          <i class="fas fa-chevron-right rotate-icon ms-auto"></i>
+        </a>
+        <ul class="nav flex-column collapse" id="submenu-dolore" data-bs-parent="#clinical-menu">
+          <li class="nav-item"><a href="#" class="nav-link ms-3" data-target="dn4-home">DN4</a></li>
+        </ul>
+      </li>
+
+      <li class="nav-item mb-2">
+        <a class="nav-link submenu-toggle collapsed" data-bs-toggle="collapse" data-bs-target="#submenu-delirium" href="#" role="button" aria-expanded="false">
+          <i class="fas fa-puzzle-piece me-2"></i>Delirium
+          <i class="fas fa-chevron-right rotate-icon ms-auto"></i>
+        </a>
+        <ul class="nav flex-column collapse" id="submenu-delirium" data-bs-parent="#clinical-menu">
+          <li class="nav-item"><a href="#" class="nav-link ms-3" data-target="4at-home">4AT</a></li>
+          <li class="nav-item"><a href="#" class="nav-link ms-3" data-target="cam-home">CAM</a></li>
+        </ul>
+      </li>
+
+      <li class="nav-item mb-2">
+        <a class="nav-link submenu-toggle collapsed" data-bs-toggle="collapse" data-bs-target="#submenu-sed" href="#" role="button" aria-expanded="false">
+          <i class="fas fa-bed me-2"></i>Sedazione
+          <i class="fas fa-chevron-right rotate-icon ms-auto"></i>
+        </a>
+        <ul class="nav flex-column collapse" id="submenu-sed" data-bs-parent="#clinical-menu">
+          <li class="nav-item"><a href="#" class="nav-link ms-3" data-target="rass-home">RASS</a></li>
+          <li class="nav-item"><a href="#" class="nav-link ms-3" data-target="ramsey-home">Ramsey</a></li>
+        </ul>
+      </li>
+
+      <li class="nav-item mb-2">
+        <a class="nav-link submenu-toggle collapsed" data-bs-toggle="collapse" data-bs-target="#submenu-care" href="#" role="button" aria-expanded="false">
+          <i class="fas fa-users me-2"></i>Caregiving
+          <i class="fas fa-chevron-right rotate-icon ms-auto"></i>
+        </a>
+        <ul class="nav flex-column collapse" id="submenu-care" data-bs-parent="#clinical-menu">
+          <li class="nav-item"><a href="#" class="nav-link ms-3" data-target="zcb7-home">ZCB 7 p.ti</a></li>
+          <li class="nav-item"><a href="#" class="nav-link ms-3" data-target="famcare2-home">FAMCARE 2</a></li>
         </ul>
       </li>
 
@@ -270,14 +311,35 @@
     <!-- SEZIONE IDC-PAL -->
     <?php include __DIR__ . '/strumenti-idcpal.php'; ?>
 
-    <!-- SEZIONE PPI -->
-    <?php include __DIR__ . '/strumenti-ppi.php'; ?>
-
     <!-- SEZIONE IPOS -->
     <?php include __DIR__ . '/strumenti-ipos.php'; ?>
 
     <!-- SEZIONE PERFORMANCE -->
     <?php include __DIR__ . '/strumenti-performance.php'; ?>
+
+    <!-- SEZIONE ESAS -->
+    <?php include __DIR__ . '/strumenti-esas.php'; ?>
+
+    <!-- SEZIONE DN4 -->
+    <?php include __DIR__ . '/strumenti-dn4.php'; ?>
+
+    <!-- SEZIONE 4AT -->
+    <?php include __DIR__ . '/strumenti-4at.php'; ?>
+
+    <!-- SEZIONE CAM -->
+    <?php include __DIR__ . '/strumenti-cam.php'; ?>
+
+    <!-- SEZIONE RASS -->
+    <?php include __DIR__ . '/strumenti-rass.php'; ?>
+
+    <!-- SEZIONE RAMSEY -->
+    <?php include __DIR__ . '/strumenti-ramsey.php'; ?>
+
+    <!-- SEZIONE ZCB 7 -->
+    <?php include __DIR__ . '/strumenti-zcb7.php'; ?>
+
+    <!-- SEZIONE FAMCARE 2 -->
+    <?php include __DIR__ . '/strumenti-famcare2.php'; ?>
   </div>
 </div>
 

--- a/gestione-sintomi/index.php
+++ b/gestione-sintomi/index.php
@@ -104,13 +104,13 @@
       </li>
 
       <li class="nav-item mb-2">
-        <a class="nav-link submenu-toggle collapsed" data-bs-toggle="collapse" data-bs-target="#submenu-prog" href="#" role="button" aria-expanded="false">
+        <a class="nav-link submenu-toggle collapsed" data-bs-toggle="collapse" data-bs-target="#submenu-prog" href="#" role="button" aria-expanded="false" data-target="prognosi-home">
           <i class="fas fa-chart-line me-2"></i>Prognosi
           <i class="fas fa-chevron-right rotate-icon ms-auto"></i>
         </a>
         <ul class="nav flex-column collapse" id="submenu-prog" data-bs-parent="#clinical-menu">
-          <li class="nav-item"><a href="strumenti-prognosi.php?scale=ppi" class="nav-link ms-3">PPI</a></li>
-          <li class="nav-item"><a href="strumenti-prognosi.php?scale=pap" class="nav-link ms-3">PaP Score</a></li>
+          <li class="nav-item"><a href="#" class="nav-link ms-3" onclick="openProgModal('ppi');">PPI</a></li>
+          <li class="nav-item"><a href="#" class="nav-link ms-3" onclick="openProgModal('pap');">PaP Score</a></li>
         </ul>
       </li>
 
@@ -316,6 +316,9 @@
 
     <!-- SEZIONE PERFORMANCE -->
     <?php include __DIR__ . '/strumenti-performance.php'; ?>
+
+    <!-- SEZIONE PROGNOSI -->
+    <?php include __DIR__ . '/strumenti-prognosi.php'; ?>
 
     <!-- SEZIONE ESAS -->
     <?php include __DIR__ . '/strumenti-esas.php'; ?>

--- a/gestione-sintomi/js/app.js
+++ b/gestione-sintomi/js/app.js
@@ -21,7 +21,7 @@ document.addEventListener("DOMContentLoaded", function() {
       const sections = [
         'dashboard-home','gestione-home','sedazione-home',
         'identificazione-home','necpal4-home','spict-home',
-        'idcpal-home','ppi-home','ipos-home','performance-home',
+        'idcpal-home','performance-home','prognosi-home','ipos-home',
         'equianalgesia-section','rescue-section'
       ];
       sections.forEach(id => {

--- a/gestione-sintomi/strumenti-4at.php
+++ b/gestione-sintomi/strumenti-4at.php
@@ -1,0 +1,10 @@
+<?php
+// placeholder per 4AT
+?>
+<section id="4at-home" class="p-4" style="display:none;">
+  <div class="bg-white p-4 rounded shadow-sm">
+    <h5 class="mb-3"><i class="fas fa-puzzle-piece me-2"></i>4AT</h5>
+    <p>Sezione in costruzione.</p>
+  </div>
+</section>
+

--- a/gestione-sintomi/strumenti-cam.php
+++ b/gestione-sintomi/strumenti-cam.php
@@ -1,0 +1,10 @@
+<?php
+// placeholder per CAM
+?>
+<section id="cam-home" class="p-4" style="display:none;">
+  <div class="bg-white p-4 rounded shadow-sm">
+    <h5 class="mb-3"><i class="fas fa-puzzle-piece me-2"></i>CAM</h5>
+    <p>Sezione in costruzione.</p>
+  </div>
+</section>
+

--- a/gestione-sintomi/strumenti-dn4.php
+++ b/gestione-sintomi/strumenti-dn4.php
@@ -1,0 +1,10 @@
+<?php
+// placeholder per DN4
+?>
+<section id="dn4-home" class="p-4" style="display:none;">
+  <div class="bg-white p-4 rounded shadow-sm">
+    <h5 class="mb-3"><i class="fas fa-face-frown me-2"></i>DN4</h5>
+    <p>Sezione in costruzione.</p>
+  </div>
+</section>
+

--- a/gestione-sintomi/strumenti-esas.php
+++ b/gestione-sintomi/strumenti-esas.php
@@ -1,0 +1,10 @@
+<?php
+// placeholder per ESAS
+?>
+<section id="esas-home" class="p-4" style="display:none;">
+  <div class="bg-white p-4 rounded shadow-sm">
+    <h5 class="mb-3"><i class="fas fa-clipboard me-2"></i>ESAS</h5>
+    <p>Sezione in costruzione.</p>
+  </div>
+</section>
+

--- a/gestione-sintomi/strumenti-famcare2.php
+++ b/gestione-sintomi/strumenti-famcare2.php
@@ -1,0 +1,10 @@
+<?php
+// placeholder per FAMCARE 2
+?>
+<section id="famcare2-home" class="p-4" style="display:none;">
+  <div class="bg-white p-4 rounded shadow-sm">
+    <h5 class="mb-3"><i class="fas fa-users me-2"></i>FAMCARE 2</h5>
+    <p>Sezione in costruzione.</p>
+  </div>
+</section>
+

--- a/gestione-sintomi/strumenti-ppi.php
+++ b/gestione-sintomi/strumenti-ppi.php
@@ -1,9 +1,0 @@
-<?php
-// placeholder per PPI
-?>
-<section id="ppi-home" class="p-4" style="display:none;">
-  <div class="bg-white p-4 rounded shadow-sm">
-    <h5 class="mb-3"><i class="fas fa-hourglass-half me-2"></i>PPI</h5>
-    <p>Sezione in costruzione.</p>
-  </div>
-</section>

--- a/gestione-sintomi/strumenti-prognosi.php
+++ b/gestione-sintomi/strumenti-prognosi.php
@@ -1,0 +1,1022 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Prognosi - Medbox.it</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Arial', sans-serif;
+            background-color: #f8f9fa;
+            color: #333;
+            line-height: 1.6;
+        }
+
+        .prognosi-container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 2rem 1rem;
+        }
+        
+        .prognosi-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+            gap: 2rem;
+            margin-top: 2rem;
+        }
+        
+        .prognosi-card {
+            background: white;
+            border-radius: 12px;
+            box-shadow: 0 4px 20px rgba(0,0,0,0.08);
+            padding: 2rem;
+            transition: all 0.3s ease;
+            border: 1px solid #e9ecef;
+            cursor: pointer;
+        }
+        
+        .prognosi-card:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 8px 30px rgba(0,0,0,0.15);
+            border-color: #5cb85c;
+        }
+        
+        .card-header {
+            display: flex;
+            align-items: center;
+            margin-bottom: 1.5rem;
+        }
+        
+        .card-icon {
+            width: 50px;
+            height: 50px;
+            border-radius: 10px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 1.5rem;
+            color: white;
+            margin-right: 1rem;
+            font-weight: bold;
+        }
+        
+        .ppi .card-icon { background: linear-gradient(135deg, #e74c3c, #c0392b); }
+        .pap .card-icon { background: linear-gradient(135deg, #9b59b6, #8e44ad); }
+        
+        .card-title {
+            font-size: 1.4rem;
+            font-weight: 600;
+            color: #5cb85c;
+            margin-bottom: 0.3rem;
+        }
+        
+        .card-subtitle {
+            font-size: 0.9rem;
+            color: #6c757d;
+            font-weight: 500;
+        }
+        
+        .card-description {
+            color: #555;
+            margin-bottom: 1.5rem;
+            font-size: 0.95rem;
+        }
+        
+        .card-features {
+            list-style: none;
+        }
+        
+        .card-features li {
+            padding: 0.3rem 0;
+            font-size: 0.9rem;
+            color: #666;
+            position: relative;
+            padding-left: 1.2rem;
+        }
+        
+        .card-features li:before {
+            content: "📊";
+            position: absolute;
+            left: 0;
+            font-size: 0.8rem;
+        }
+        
+        .card-footer {
+            margin-top: 1.5rem;
+            padding-top: 1rem;
+            border-top: 1px solid #e9ecef;
+            font-size: 0.85rem;
+            color: #6c757d;
+        }
+        
+        .modal {
+            display: none;
+            position: fixed;
+            z-index: 1000;
+            left: 0;
+            top: 0;
+            width: 100%;
+            height: 100%;
+            background-color: rgba(0,0,0,0.5);
+        }
+        
+        .modal-content {
+            background-color: white;
+            margin: 2% auto;
+            padding: 2rem;
+            border-radius: 12px;
+            width: 95%;
+            max-width: 900px;
+            max-height: 90vh;
+            overflow-y: auto;
+            position: relative;
+        }
+        
+        .close {
+            position: absolute;
+            right: 1rem;
+            top: 1rem;
+            font-size: 2rem;
+            font-weight: bold;
+            cursor: pointer;
+            color: #aaa;
+        }
+        
+        .close:hover { color: #000; }
+        
+        .modal h3 {
+            color: #5cb85c;
+            margin-bottom: 1rem;
+            font-size: 1.8rem;
+        }
+        
+        /* Sistema Tab */
+        .tabs {
+            display: flex;
+            margin-bottom: 2rem;
+            border-bottom: 2px solid #e9ecef;
+        }
+        
+        .tab {
+            padding: 1rem 2rem;
+            cursor: pointer;
+            border: none;
+            background: none;
+            font-size: 1rem;
+            color: #6c757d;
+            border-bottom: 2px solid transparent;
+            transition: all 0.3s ease;
+        }
+        
+        .tab.active {
+            color: #5cb85c;
+            border-bottom-color: #5cb85c;
+        }
+        
+        .tab:hover {
+            color: #5cb85c;
+        }
+        
+        .tab-content {
+            display: none;
+        }
+        
+        .tab-content.active {
+            display: block;
+        }
+        
+        /* Stili Form */
+        .patient-info {
+            background: #f8f9fa;
+            padding: 1.5rem;
+            border-radius: 8px;
+            margin-bottom: 2rem;
+        }
+        
+        .patient-info h4 {
+            color: #5cb85c;
+            margin-bottom: 1rem;
+        }
+        
+        .patient-info input {
+            width: 100%;
+            padding: 0.5rem;
+            border: 1px solid #dee2e6;
+            border-radius: 4px;
+            margin-bottom: 1rem;
+        }
+        
+        .form-group {
+            margin-bottom: 1.5rem;
+            padding: 1rem;
+            background: #f8f9fa;
+            border-radius: 8px;
+        }
+        
+        .form-group h4 {
+            color: #5cb85c;
+            margin-bottom: 1rem;
+        }
+        
+        .form-item {
+            margin-bottom: 1.5rem;
+            padding: 1rem;
+            background: white;
+            border-radius: 8px;
+            border-left: 4px solid #dee2e6;
+        }
+        
+        .form-item.completed {
+            border-left-color: #28a745;
+        }
+        
+        .form-item label {
+            display: block;
+            font-weight: 600;
+            margin-bottom: 0.5rem;
+            color: #495057;
+        }
+        
+        .radio-group {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1rem;
+            margin-top: 0.5rem;
+        }
+        
+        .radio-option {
+            display: flex;
+            align-items: center;
+            cursor: pointer;
+            padding: 0.5rem 1rem;
+            border: 2px solid #dee2e6;
+            border-radius: 25px;
+            transition: all 0.3s ease;
+            min-width: 150px;
+        }
+        
+        .radio-option:hover {
+            border-color: #5cb85c;
+            background: #f0f7ff;
+        }
+        
+        .radio-option.selected {
+            border-color: #28a745;
+            background: #d4edda;
+            color: #155724;
+        }
+        
+        .radio-option input[type="radio"] {
+            margin-right: 0.5rem;
+        }
+        
+        .score-display {
+            background: linear-gradient(135deg, #5cb85c, #449d44);
+            color: white;
+            padding: 2rem;
+            border-radius: 12px;
+            text-align: center;
+            margin: 2rem 0;
+        }
+        
+        .score-number {
+            font-size: 3rem;
+            font-weight: bold;
+            margin-bottom: 0.5rem;
+        }
+        
+        .score-interpretation {
+            font-size: 1.2rem;
+            margin-bottom: 1rem;
+        }
+        
+        .score-description {
+            font-size: 1rem;
+            opacity: 0.9;
+        }
+        
+        /* Tabelle di riferimento */
+        .scale-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 1rem 0;
+            font-size: 0.9rem;
+        }
+        
+        .scale-table th,
+        .scale-table td {
+            border: 1px solid #dee2e6;
+            padding: 0.75rem;
+            text-align: left;
+        }
+        
+        .scale-table th {
+            background-color: #f8f9fa;
+            font-weight: 600;
+            color: #495057;
+        }
+        
+        .scale-table tbody tr:nth-child(even) {
+            background-color: #f8f9fa;
+        }
+        
+        /* Bottoni */
+        .btn {
+            padding: 0.75rem 2rem;
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 1rem;
+            transition: all 0.3s ease;
+            margin: 0.5rem;
+        }
+        
+        .btn-success {
+            background: #28a745;
+            color: white;
+        }
+        
+        .btn-success:hover {
+            background: #218838;
+        }
+        
+        .reset-btn {
+            background: #dc3545;
+            color: white;
+        }
+        
+        .reset-btn:hover {
+            background: #c82333;
+        }
+
+        .progress-bar {
+            background: #e9ecef;
+            border-radius: 10px;
+            height: 8px;
+            margin: 1rem 0;
+        }
+
+        .progress-fill {
+            background: linear-gradient(90deg, #28a745, #20c997);
+            height: 100%;
+            border-radius: 10px;
+            transition: width 0.3s ease;
+        }
+        
+        /* Responsive */
+        @media (max-width: 768px) {
+            .prognosi-grid {
+                grid-template-columns: 1fr;
+            }
+            
+            .modal-content {
+                width: 98%;
+                margin: 1% auto;
+                padding: 1rem;
+            }
+            
+            .tabs {
+                flex-wrap: wrap;
+            }
+            
+            .tab {
+                padding: 0.75rem 1rem;
+                font-size: 0.9rem;
+            }
+            
+            .radio-group {
+                flex-direction: column;
+            }
+            
+            .radio-option {
+                min-width: auto;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="prognosi-container">
+        <h1 style="color: #5cb85c; text-align: center; margin-bottom: 1rem;">Strumenti di Prognosi</h1>
+        <p style="text-align: center; color: #666; margin-bottom: 2rem;">Scale prognostiche validate per la valutazione dell'aspettativa di vita in cure palliative</p>
+        
+        <div class="prognosi-grid">
+            <div class="prognosi-card ppi" onclick="openModal('ppi')">
+                <div class="card-header">
+                    <div class="card-icon">PPI</div>
+                    <div>
+                        <div class="card-title">PPI</div>
+                        <div class="card-subtitle">Palliative Performance Index</div>
+                    </div>
+                </div>
+                <div class="card-description">
+                    Strumento prognostico per stimare la sopravvivenza nei pazienti in cure palliative, basato su 5 parametri clinici facilmente valutabili.
+                </div>
+                <ul class="card-features">
+                    <li>5 parametri di valutazione</li>
+                    <li>Predizione sopravvivenza a 3 e 6 settimane</li>
+                    <li>Calcolo automatico del punteggio</li>
+                    <li>Validato internazionalmente</li>
+                </ul>
+                <div class="card-footer">
+                    Clicca per compilare la scala
+                </div>
+            </div>
+
+            <div class="prognosi-card pap" onclick="openModal('pap')">
+                <div class="card-header">
+                    <div class="card-icon">PaP</div>
+                    <div>
+                        <div class="card-title">PaP Score</div>
+                        <div class="card-subtitle">Palliative Prognostic Score</div>
+                    </div>
+                </div>
+                <div class="card-description">
+                    Score prognostico multidimensionale che combina valutazione clinica e parametri laboratoristici per predire la sopravvivenza a 30 giorni.
+                </div>
+                <ul class="card-features">
+                    <li>6 parametri clinici e laboratoristici</li>
+                    <li>3 gruppi di rischio prognostico (A/B/C)</li>
+                    <li>Predizione sopravvivenza a 30 giorni</li>
+                    <li>Ampiamente utilizzato in letteratura</li>
+                </ul>
+                <div class="card-footer">
+                    Clicca per compilare la scala
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Modal PPI -->
+    <div id="modal-ppi" class="modal">
+        <div class="modal-content">
+            <span class="close" onclick="closeModal('ppi')">&times;</span>
+            <h3>PPI - Palliative Performance Index</h3>
+            
+            <div class="tabs">
+                <button class="tab active" onclick="showTab('ppi', 'compile')">📝 Compila</button>
+                <button class="tab" onclick="showTab('ppi', 'view')">📊 Visualizza Scala</button>
+            </div>
+
+            <!-- Tab Compila PPI -->
+            <div id="ppi-compile" class="tab-content active">
+                <div class="patient-info">
+                    <h4>Dati Paziente</h4>
+                    <input type="text" id="ppi-patient-name" placeholder="Nome paziente" />
+                    <input type="date" id="ppi-date" />
+                </div>
+
+                <div class="form-group">
+                    <h4>Compila i 5 parametri del PPI:</h4>
+                    <div style="margin-bottom: 1rem;">
+                        <div class="progress-bar">
+                            <div class="progress-fill" id="ppi-progress" style="width: 0%"></div>
+                        </div>
+                        <small style="color: #666;">Progresso: <span id="ppi-progress-text">0/5</span> parametri completati</small>
+                    </div>
+                    
+                    <div class="form-item" id="ppi-pps-item">
+                        <label>1. Palliative Performance Scale (PPS)</label>
+                        <div class="radio-group">
+                            <div class="radio-option" onclick="selectPPI('pps', 4)">
+                                <input type="radio" name="ppi-pps" value="4">
+                                <span>10-20% (4 punti)</span>
+                            </div>
+                            <div class="radio-option" onclick="selectPPI('pps', 2.5)">
+                                <input type="radio" name="ppi-pps" value="2.5">
+                                <span>30-50% (2.5 punti)</span>
+                            </div>
+                            <div class="radio-option" onclick="selectPPI('pps', 0)">
+                                <input type="radio" name="ppi-pps" value="0">
+                                <span>>60% (0 punti)</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="form-item" id="ppi-oral-item">
+                        <label>2. Assunzione orale</label>
+                        <div class="radio-group">
+                            <div class="radio-option" onclick="selectPPI('oral', 2.5)">
+                                <input type="radio" name="ppi-oral" value="2.5">
+                                <span>Severamente ridotta (2.5 punti)</span>
+                            </div>
+                            <div class="radio-option" onclick="selectPPI('oral', 1)">
+                                <input type="radio" name="ppi-oral" value="1">
+                                <span>Moderatamente ridotta (1 punto)</span>
+                            </div>
+                            <div class="radio-option" onclick="selectPPI('oral', 0)">
+                                <input type="radio" name="ppi-oral" value="0">
+                                <span>Normale (0 punti)</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="form-item" id="ppi-edema-item">
+                        <label>3. Edema</label>
+                        <div class="radio-group">
+                            <div class="radio-option" onclick="selectPPI('edema', 1)">
+                                <input type="radio" name="ppi-edema" value="1">
+                                <span>Presente (1 punto)</span>
+                            </div>
+                            <div class="radio-option" onclick="selectPPI('edema', 0)">
+                                <input type="radio" name="ppi-edema" value="0">
+                                <span>Assente (0 punti)</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="form-item" id="ppi-dyspnea-item">
+                        <label>4. Dispnea a riposo</label>
+                        <div class="radio-group">
+                            <div class="radio-option" onclick="selectPPI('dyspnea', 3.5)">
+                                <input type="radio" name="ppi-dyspnea" value="3.5">
+                                <span>Presente (3.5 punti)</span>
+                            </div>
+                            <div class="radio-option" onclick="selectPPI('dyspnea', 0)">
+                                <input type="radio" name="ppi-dyspnea" value="0">
+                                <span>Assente (0 punti)</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="form-item" id="ppi-delirium-item">
+                        <label>5. Delirium</label>
+                        <div class="radio-group">
+                            <div class="radio-option" onclick="selectPPI('delirium', 4)">
+                                <input type="radio" name="ppi-delirium" value="4">
+                                <span>Presente (4 punti)</span>
+                            </div>
+                            <div class="radio-option" onclick="selectPPI('delirium', 0)">
+                                <input type="radio" name="ppi-delirium" value="0">
+                                <span>Assente (0 punti)</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div id="ppi-results" class="score-display" style="display: none;">
+                    <div class="score-number" id="ppi-score">0</div>
+                    <div class="score-interpretation" id="ppi-interpretation">Punteggio PPI</div>
+                    <div class="score-description" id="ppi-description">Completa tutti i parametri per la valutazione prognostica</div>
+                </div>
+
+                <div style="text-align: center;">
+                    <button class="btn btn-success" onclick="generateReport('ppi')">📄 Genera Report</button>
+                    <button class="btn reset-btn" onclick="resetForm('ppi')">🔄 Azzera</button>
+                </div>
+            </div>
+
+            <!-- Tab Visualizza Scala PPI -->
+            <div id="ppi-view" class="tab-content">
+                <h4>Palliative Performance Index (PPI)</h4>
+                <table class="scale-table">
+                    <thead>
+                        <tr>
+                            <th>Parametro</th>
+                            <th>Valore</th>
+                            <th>Punteggio</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr><td rowspan="3"><strong>Palliative Performance Scale</strong></td><td>10-20%</td><td>4.0</td></tr>
+                        <tr><td>30-50%</td><td>2.5</td></tr>
+                        <tr><td>>60%</td><td>0</td></tr>
+                        <tr><td rowspan="3"><strong>Assunzione orale</strong></td><td>Severamente ridotta</td><td>2.5</td></tr>
+                        <tr><td>Moderatamente ridotta</td><td>1.0</td></tr>
+                        <tr><td>Normale</td><td>0</td></tr>
+                        <tr><td rowspan="2"><strong>Edema</strong></td><td>Presente</td><td>1.0</td></tr>
+                        <tr><td>Assente</td><td>0</td></tr>
+                        <tr><td rowspan="2"><strong>Dispnea a riposo</strong></td><td>Presente</td><td>3.5</td></tr>
+                        <tr><td>Assente</td><td>0</td></tr>
+                        <tr><td rowspan="2"><strong>Delirium</strong></td><td>Presente</td><td>4.0</td></tr>
+                        <tr><td>Assente</td><td>0</td></tr>
+                    </tbody>
+                </table>
+                
+                <div style="background: #f8f9fa; padding: 1.5rem; border-radius: 8px; margin-top: 1.5rem;">
+                    <h5 style="color: #e74c3c; margin-bottom: 1rem;">📈 Interpretazione Prognostica:</h5>
+                    <ul style="margin: 0; padding-left: 1.5rem; color: #666;">
+                        <li><strong>PPI ≤ 4:</strong> Sopravvivenza >6 settimane (probabilità >70%)</li>
+                        <li><strong>PPI > 4:</strong> Sopravvivenza ≤3 settimane (probabilità >80%)</li>
+                        <li><strong>Punteggio totale:</strong> 0-15 punti</li>
+                        <li><strong>Maggiore è il punteggio, minore è la sopravvivenza attesa</strong></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Modal PaP Score -->
+    <div id="modal-pap" class="modal">
+        <div class="modal-content">
+            <span class="close" onclick="closeModal('pap')">&times;</span>
+            <h3>PaP Score - Palliative Prognostic Score</h3>
+            
+            <div class="tabs">
+                <button class="tab active" onclick="showTab('pap', 'compile')">📝 Compila</button>
+                <button class="tab" onclick="showTab('pap', 'view')">📊 Visualizza Scala</button>
+            </div>
+
+            <!-- Tab Compila PaP -->
+            <div id="pap-compile" class="tab-content active">
+                <div class="patient-info">
+                    <h4>Dati Paziente</h4>
+                    <input type="text" id="pap-patient-name" placeholder="Nome paziente" />
+                    <input type="date" id="pap-date" />
+                </div>
+
+                <div class="form-group">
+                    <h4>Compila i 6 parametri del PaP Score:</h4>
+                    <div style="margin-bottom: 1rem;">
+                        <div class="progress-bar">
+                            <div class="progress-fill" id="pap-progress" style="width: 0%"></div>
+                        </div>
+                        <small style="color: #666;">Progresso: <span id="pap-progress-text">0/6</span> parametri completati</small>
+                    </div>
+                    
+                    <div class="form-item" id="pap-dyspnea-item">
+                        <label>1. Dispnea</label>
+                        <div class="radio-group">
+                            <div class="radio-option" onclick="selectPAP('dyspnea', 1)">
+                                <input type="radio" name="pap-dyspnea" value="1">
+                                <span>Sì (1 punto)</span>
+                            </div>
+                            <div class="radio-option" onclick="selectPAP('dyspnea', 0)">
+                                <input type="radio" name="pap-dyspnea" value="0">
+                                <span>No (0 punti)</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="form-item" id="pap-anorexia-item">
+                        <label>2. Anoressia</label>
+                        <div class="radio-group">
+                            <div class="radio-option" onclick="selectPAP('anorexia', 1)">
+                                <input type="radio" name="pap-anorexia" value="1">
+                                <span>Sì (1 punto)</span>
+                            </div>
+                            <div class="radio-option" onclick="selectPAP('anorexia', 0)">
+                                <input type="radio" name="pap-anorexia" value="0">
+                                <span>No (0 punti)</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="form-item" id="pap-karnofsky-item">
+                        <label>3. Karnofsky Performance Status</label>
+                        <div class="radio-group">
+                            <div class="radio-option" onclick="selectPAP('karnofsky', 2.5)">
+                                <input type="radio" name="pap-karnofsky" value="2.5">
+                                <span>10-20 (2.5 punti)</span>
+                            </div>
+                            <div class="radio-option" onclick="selectPAP('karnofsky', 0)">
+                                <input type="radio" name="pap-karnofsky" value="0">
+                                <span>30-100 (0 punti)</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="form-item" id="pap-wbc-item">
+                        <label>4. Leucociti totali</label>
+                        <div class="radio-group">
+                            <div class="radio-option" onclick="selectPAP('wbc', 1.5)">
+                                <input type="radio" name="pap-wbc" value="1.5">
+                                <span>>11.000 (1.5 punti)</span>
+                            </div>
+                            <div class="radio-option" onclick="selectPAP('wbc', 0.5)">
+                                <input type="radio" name="pap-wbc" value="0.5">
+                                <span>8.501-11.000 (0.5 punti)</span>
+                            </div>
+                            <div class="radio-option" onclick="selectPAP('wbc', 0)">
+                                <input type="radio" name="pap-wbc" value="0">
+                                <span>≤8.500 (0 punti)</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="form-item" id="pap-lymphocytes-item">
+                        <label>5. Percentuale Linfociti</label>
+                        <div class="radio-group">
+                            <div class="radio-option" onclick="selectPAP('lymphocytes', 2.5)">
+                                <input type="radio" name="pap-lymphocytes" value="2.5">
+                                <span>0-11.9% (2.5 punti)</span>
+                            </div>
+                            <div class="radio-option" onclick="selectPAP('lymphocytes', 1)">
+                                <input type="radio" name="pap-lymphocytes" value="1">
+                                <span>12-19.9% (1 punto)</span>
+                            </div>
+                            <div class="radio-option" onclick="selectPAP('lymphocytes', 0)">
+                                <input type="radio" name="pap-lymphocytes" value="0">
+                                <span>≥20% (0 punti)</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="form-item" id="pap-prediction-item">
+                        <label>6. Predizione clinica di sopravvivenza</label>
+                        <div class="radio-group">
+                            <div class="radio-option" onclick="selectPAP('prediction', 8.5)">
+                                <input type="radio" name="pap-prediction" value="8.5">
+                                <span>1-2 settimane (8.5 punti)</span>
+                            </div>
+                            <div class="radio-option" onclick="selectPAP('prediction', 6)">
+                                <input type="radio" name="pap-prediction" value="6">
+                                <span>3-4 settimane (6 punti)</span>
+                            </div>
+                            <div class="radio-option" onclick="selectPAP('prediction', 4.5)">
+                                <input type="radio" name="pap-prediction" value="4.5">
+                                <span>5-6 settimane (4.5 punti)</span>
+                            </div>
+                            <div class="radio-option" onclick="selectPAP('prediction', 2.5)">
+                                <input type="radio" name="pap-prediction" value="2.5">
+                                <span>7-10 settimane (2.5 punti)</span>
+                            </div>
+                            <div class="radio-option" onclick="selectPAP('prediction', 0)">
+                                <input type="radio" name="pap-prediction" value="0">
+                                <span>>10 settimane (0 punti)</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div id="pap-results" class="score-display" style="display: none;">
+                    <div class="score-number" id="pap-score">0</div>
+                    <div class="score-interpretation" id="pap-interpretation">Punteggio PaP</div>
+                    <div class="score-description" id="pap-description">Completa tutti i parametri per la valutazione prognostica</div>
+                </div>
+
+                <div style="text-align: center;">
+                    <button class="btn btn-success" onclick="generateReport('pap')">📄 Genera Report</button>
+                    <button class="btn reset-btn" onclick="resetForm('pap')">🔄 Azzera</button>
+                </div>
+            </div>
+
+            <!-- Tab Visualizza Scala PaP -->
+            <div id="pap-view" class="tab-content">
+                <h4>Palliative Prognostic Score (PaP)</h4>
+                <table class="scale-table">
+                    <thead>
+                        <tr>
+                            <th>Parametro</th>
+                            <th>Valore</th>
+                            <th>Punteggio</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr><td rowspan="2"><strong>Dispnea</strong></td><td>Sì</td><td>1.0</td></tr>
+                        <tr><td>No</td><td>0</td></tr>
+                        <tr><td rowspan="2"><strong>Anoressia</strong></td><td>Sì</td><td>1.0</td></tr>
+                        <tr><td>No</td><td>0</td></tr>
+                        <tr><td rowspan="2"><strong>Karnofsky Performance Status</strong></td><td>10-20</td><td>2.5</td></tr>
+                        <tr><td>30-100</td><td>0</td></tr>
+                        <tr><td rowspan="3"><strong>Leucociti totali</strong></td><td>>11.000</td><td>1.5</td></tr>
+                        <tr><td>8.501-11.000</td><td>0.5</td></tr>
+                        <tr><td>≤8.500</td><td>0</td></tr>
+                        <tr><td rowspan="3"><strong>% Linfociti</strong></td><td>0-11.9%</td><td>2.5</td></tr>
+                        <tr><td>12-19.9%</td><td>1.0</td></tr>
+                        <tr><td>≥20%</td><td>0</td></tr>
+                        <tr><td rowspan="5"><strong>Predizione clinica</strong></td><td>1-2 settimane</td><td>8.5</td></tr>
+                        <tr><td>3-4 settimane</td><td>6.0</td></tr>
+                        <tr><td>5-6 settimane</td><td>4.5</td></tr>
+                        <tr><td>7-10 settimane</td><td>2.5</td></tr>
+                        <tr><td>>10 settimane</td><td>0</td></tr>
+                    </tbody>
+                </table>
+                
+                <div style="background: #f8f9fa; padding: 1.5rem; border-radius: 8px; margin-top: 1.5rem;">
+                    <h5 style="color: #9b59b6; margin-bottom: 1rem;">📈 Interpretazione Prognostica:</h5>
+                    <ul style="margin: 0; padding-left: 1.5rem; color: #666;">
+                        <li><strong>Gruppo A (0-5.5 punti):</strong> Sopravvivenza >30 giorni (probabilità >70%)</li>
+                        <li><strong>Gruppo B (5.6-11 punti):</strong> Sopravvivenza incerta (30-70%)</li>
+                        <li><strong>Gruppo C (11.1-17.5 punti):</strong> Sopravvivenza <30 giorni (probabilità >70%)</li>
+                        <li><strong>Punteggio totale:</strong> 0-17.5 punti</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        // Variabili globali per i punteggi
+        let ppiData = {
+            pps: null,
+            oral: null,
+            edema: null,
+            dyspnea: null,
+            delirium: null
+        };
+
+        let papData = {
+            dyspnea: null,
+            anorexia: null,
+            karnofsky: null,
+            wbc: null,
+            lymphocytes: null,
+            prediction: null
+        };
+
+        // Funzioni per aprire/chiudere modal
+        function openModal(type) {
+            document.getElementById(`modal-${type}`).style.display = 'block';
+            document.getElementById(`${type}-date`).value = new Date().toISOString().split('T')[0];
+        }
+
+        function closeModal(type) {
+            document.getElementById(`modal-${type}`).style.display = 'none';
+        }
+
+        // Funzione per gestire i tab
+        function showTab(scale, tab) {
+            const tabContents = document.querySelectorAll(`#modal-${scale} .tab-content`);
+            tabContents.forEach(content => content.classList.remove('active'));
+            const tabs = document.querySelectorAll(`#modal-${scale} .tab`);
+            tabs.forEach(t => t.classList.remove('active'));
+            document.getElementById(`${scale}-${tab}`).classList.add('active');
+            event.target.classList.add('active');
+        }
+
+        // Funzione per selezionare opzioni PPI
+        function selectPPI(parameter, value) {
+            const radioGroup = event.target.closest('.radio-group');
+            radioGroup.querySelectorAll('.radio-option').forEach(option => {
+                option.classList.remove('selected');
+                option.querySelector('input').checked = false;
+            });
+            event.target.closest('.radio-option').classList.add('selected');
+            event.target.closest('.radio-option').querySelector('input').checked = true;
+            ppiData[parameter] = parseFloat(value);
+            document.getElementById(`ppi-${parameter}-item`).classList.add('completed');
+            updatePPIProgress();
+            calculatePPI();
+        }
+
+        // Funzione per selezionare opzioni PaP
+        function selectPAP(parameter, value) {
+            const radioGroup = event.target.closest('.radio-group');
+            radioGroup.querySelectorAll('.radio-option').forEach(option => {
+                option.classList.remove('selected');
+                option.querySelector('input').checked = false;
+            });
+            event.target.closest('.radio-option').classList.add('selected');
+            event.target.closest('.radio-option').querySelector('input').checked = true;
+            papData[parameter] = parseFloat(value);
+            document.getElementById(`pap-${parameter}-item`).classList.add('completed');
+            updatePAPProgress();
+            calculatePAP();
+        }
+
+        // Aggiorna il progresso PPI
+        function updatePPIProgress() {
+            const completed = Object.values(ppiData).filter(val => val !== null).length;
+            const total = Object.keys(ppiData).length;
+            const percentage = (completed / total) * 100;
+            document.getElementById('ppi-progress').style.width = percentage + '%';
+            document.getElementById('ppi-progress-text').textContent = `${completed}/${total}`;
+        }
+
+        // Aggiorna il progresso PaP
+        function updatePAPProgress() {
+            const completed = Object.values(papData).filter(val => val !== null).length;
+            const total = Object.keys(papData).length;
+            const percentage = (completed / total) * 100;
+            document.getElementById('pap-progress').style.width = percentage + '%';
+            document.getElementById('pap-progress-text').textContent = `${completed}/${total}`;
+        }
+
+        // Calcola il punteggio PPI
+        function calculatePPI() {
+            const completed = Object.values(ppiData).filter(val => val !== null).length;
+            if (completed === Object.keys(ppiData).length) {
+                const totalScore = Object.values(ppiData).reduce((sum, val) => sum + val, 0);
+                let interpretation = '';
+                let description = '';
+                if (totalScore <= 4) {
+                    interpretation = 'Buona prognosi';
+                    description = 'Sopravvivenza >6 settimane (probabilità >70%)';
+                } else {
+                    interpretation = 'Prognosi riservata';
+                    description = 'Sopravvivenza ≤3 settimane (probabilità >80%)';
+                }
+                document.getElementById('ppi-score').textContent = totalScore.toFixed(1);
+                document.getElementById('ppi-interpretation').textContent = interpretation;
+                document.getElementById('ppi-description').textContent = description;
+                document.getElementById('ppi-results').style.display = 'block';
+            } else {
+                document.getElementById('ppi-results').style.display = 'none';
+            }
+        }
+
+        // Calcola il punteggio PaP
+        function calculatePAP() {
+            const completed = Object.values(papData).filter(val => val !== null).length;
+            if (completed === Object.keys(papData).length) {
+                const totalScore = Object.values(papData).reduce((sum, val) => sum + val, 0);
+                let interpretation = '';
+                let description = '';
+                let group = '';
+                if (totalScore <= 5.5) {
+                    group = 'A';
+                    interpretation = 'Buona prognosi';
+                    description = 'Sopravvivenza >30 giorni (probabilità >70%)';
+                } else if (totalScore <= 11) {
+                    group = 'B';
+                    interpretation = 'Prognosi intermedia';
+                    description = 'Sopravvivenza incerta (30-70% probabilità)';
+                } else {
+                    group = 'C';
+                    interpretation = 'Prognosi riservata';
+                    description = 'Sopravvivenza <30 giorni (probabilità >70%)';
+                }
+                document.getElementById('pap-score').textContent = totalScore.toFixed(1);
+                document.getElementById('pap-interpretation').textContent = `Gruppo ${group} - ${interpretation}`;
+                document.getElementById('pap-description').textContent = description;
+                document.getElementById('pap-results').style.display = 'block';
+            } else {
+                document.getElementById('pap-results').style.display = 'none';
+            }
+        }
+
+        // Reset del form
+        function resetForm(type) {
+            if (confirm('Sei sicuro di voler azzerare tutti i dati?')) {
+                if (type === 'ppi') {
+                    ppiData = { pps: null, oral: null, edema: null, dyspnea: null, delirium: null };
+                    document.getElementById('ppi-patient-name').value = '';
+                    updatePPIProgress();
+                    document.getElementById('ppi-results').style.display = 'none';
+                } else {
+                    papData = { dyspnea: null, anorexia: null, karnofsky: null, wbc: null, lymphocytes: null, prediction: null };
+                    document.getElementById('pap-patient-name').value = '';
+                    updatePAPProgress();
+                    document.getElementById('pap-results').style.display = 'none';
+                }
+                document.querySelectorAll(`#modal-${type} .radio-option`).forEach(option => {
+                    option.classList.remove('selected');
+                    option.querySelector('input').checked = false;
+                });
+                document.querySelectorAll(`#modal-${type} .form-item`).forEach(item => {
+                    item.classList.remove('completed');
+                });
+            }
+        }
+
+        // Genera report
+        function generateReport(type) {
+            const patientName = document.getElementById(`${type}-patient-name`).value || 'Paziente non specificato';
+            const date = document.getElementById(`${type}-date`).value || new Date().toISOString().split('T')[0];
+            let reportContent = '';
+            if (type === 'ppi') {
+                const completed = Object.values(ppiData).filter(val => val !== null).length;
+                if (completed < Object.keys(ppiData).length) {
+                    alert('Completa tutti i parametri prima di generare il report');
+                    return;
+                }
+                const totalScore = Object.values(ppiData).reduce((sum, val) => sum + val, 0);
+                reportContent = `\nREPORT PPI - PALLIATIVE PERFORMANCE INDEX\n==========================================\n\nPaziente: ${patientName}\nData valutazione: ${new Date(date).toLocaleDateString('it-IT')}\n\nPARAMETRI VALUTATI:\n• Palliative Performance Scale: ${ppiData.pps} punti\n• Assunzione orale: ${ppiData.oral} punti  \n• Edema: ${ppiData.edema} punti\n• Dispnea a riposo: ${ppiData.dyspnea} punti\n• Delirium: ${ppiData.delirium} punti\n\nPUNTEGGIO TOTALE: ${totalScore.toFixed(1)} punti\n\nINTERPRETAZIONE:\n${totalScore <= 4 ? 'Buona prognosi - Sopravvivenza >6 settimane (probabilità >70%)' : 'Prognosi riservata - Sopravvivenza ≤3 settimane (probabilità >80%)'}\n\nValutato da: [Nome del medico]\nFirma: ____________________\n                `;
+            } else {
+                const completed = Object.values(papData).filter(val => val !== null).length;
+                if (completed < Object.keys(papData).length) {
+                    alert('Completa tutti i parametri prima di generare il report');
+                    return;
+                }
+                const totalScore = Object.values(papData).reduce((sum, val) => sum + val, 0);
+                let group = totalScore <= 5.5 ? 'A' : totalScore <= 11 ? 'B' : 'C';
+                reportContent = `\nREPORT PAP SCORE - PALLIATIVE PROGNOSTIC SCORE\n==============================================\n\nPaziente: ${patientName}\nData valutazione: ${new Date(date).toLocaleDateString('it-IT')}\n\nPARAMETRI VALUTATI:\n• Dispnea: ${papData.dyspnea} punti\n• Anoressia: ${papData.anorexia} punti\n• Karnofsky Performance Status: ${papData.karnofsky} punti\n• Leucociti totali: ${papData.wbc} punti\n• Percentuale Linfociti: ${papData.lymphocytes} punti\n• Predizione clinica: ${papData.prediction} punti\n\nPUNTEGGIO TOTALE: ${totalScore.toFixed(1)} punti\nGRUPPO PROGNOSTICO: ${group}\n\nINTERPRETAZIONE:\n${group === 'A' ? 'Buona prognosi - Sopravvivenza >30 giorni (probabilità >70%)' : group === 'B' ? 'Prognosi intermedia - Sopravvivenza incerta (30-70% probabilità)' : 'Prognosi riservata - Sopravvivenza <30 giorni (probabilità >70%)'}\n\nValutato da: [Nome del medico]\nFirma: ____________________\n                `;
+            }
+            const blob = new Blob([reportContent], { type: 'text/plain;charset=utf-8' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = `Report_${type.toUpperCase()}_${patientName.replace(/\s+/g, '_')}_${date}.txt`;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+        }
+
+        // Chiudi modal cliccando fuori
+        window.onclick = function(event) {
+            if (event.target.classList.contains('modal')) {
+                event.target.style.display = 'none';
+            }
+        }
+
+        // Imposta la data di oggi e apertura modale da query
+        document.addEventListener('DOMContentLoaded', function() {
+            const today = new Date().toISOString().split('T')[0];
+            document.getElementById('ppi-date').value = today;
+            document.getElementById('pap-date').value = today;
+            const params = new URLSearchParams(window.location.search);
+            const scale = params.get('scale');
+            if(scale === 'ppi' || scale === 'pap') {
+                openModal(scale);
+            }
+        });
+    </script>
+</body>
+</html>

--- a/gestione-sintomi/strumenti-prognosi.php
+++ b/gestione-sintomi/strumenti-prognosi.php
@@ -1,1022 +1,327 @@
-<!DOCTYPE html>
-<html lang="it">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Prognosi - Medbox.it</title>
-    <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-
-        body {
-            font-family: 'Arial', sans-serif;
-            background-color: #f8f9fa;
-            color: #333;
-            line-height: 1.6;
-        }
-
-        .prognosi-container {
-            max-width: 1200px;
-            margin: 0 auto;
-            padding: 2rem 1rem;
-        }
-        
-        .prognosi-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
-            gap: 2rem;
-            margin-top: 2rem;
-        }
-        
-        .prognosi-card {
-            background: white;
-            border-radius: 12px;
-            box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-            padding: 2rem;
-            transition: all 0.3s ease;
-            border: 1px solid #e9ecef;
-            cursor: pointer;
-        }
-        
-        .prognosi-card:hover {
-            transform: translateY(-5px);
-            box-shadow: 0 8px 30px rgba(0,0,0,0.15);
-            border-color: #5cb85c;
-        }
-        
-        .card-header {
-            display: flex;
-            align-items: center;
-            margin-bottom: 1.5rem;
-        }
-        
-        .card-icon {
-            width: 50px;
-            height: 50px;
-            border-radius: 10px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-size: 1.5rem;
-            color: white;
-            margin-right: 1rem;
-            font-weight: bold;
-        }
-        
-        .ppi .card-icon { background: linear-gradient(135deg, #e74c3c, #c0392b); }
-        .pap .card-icon { background: linear-gradient(135deg, #9b59b6, #8e44ad); }
-        
-        .card-title {
-            font-size: 1.4rem;
-            font-weight: 600;
-            color: #5cb85c;
-            margin-bottom: 0.3rem;
-        }
-        
-        .card-subtitle {
-            font-size: 0.9rem;
-            color: #6c757d;
-            font-weight: 500;
-        }
-        
-        .card-description {
-            color: #555;
-            margin-bottom: 1.5rem;
-            font-size: 0.95rem;
-        }
-        
-        .card-features {
-            list-style: none;
-        }
-        
-        .card-features li {
-            padding: 0.3rem 0;
-            font-size: 0.9rem;
-            color: #666;
-            position: relative;
-            padding-left: 1.2rem;
-        }
-        
-        .card-features li:before {
-            content: "📊";
-            position: absolute;
-            left: 0;
-            font-size: 0.8rem;
-        }
-        
-        .card-footer {
-            margin-top: 1.5rem;
-            padding-top: 1rem;
-            border-top: 1px solid #e9ecef;
-            font-size: 0.85rem;
-            color: #6c757d;
-        }
-        
-        .modal {
-            display: none;
-            position: fixed;
-            z-index: 1000;
-            left: 0;
-            top: 0;
-            width: 100%;
-            height: 100%;
-            background-color: rgba(0,0,0,0.5);
-        }
-        
-        .modal-content {
-            background-color: white;
-            margin: 2% auto;
-            padding: 2rem;
-            border-radius: 12px;
-            width: 95%;
-            max-width: 900px;
-            max-height: 90vh;
-            overflow-y: auto;
-            position: relative;
-        }
-        
-        .close {
-            position: absolute;
-            right: 1rem;
-            top: 1rem;
-            font-size: 2rem;
-            font-weight: bold;
-            cursor: pointer;
-            color: #aaa;
-        }
-        
-        .close:hover { color: #000; }
-        
-        .modal h3 {
-            color: #5cb85c;
-            margin-bottom: 1rem;
-            font-size: 1.8rem;
-        }
-        
-        /* Sistema Tab */
-        .tabs {
-            display: flex;
-            margin-bottom: 2rem;
-            border-bottom: 2px solid #e9ecef;
-        }
-        
-        .tab {
-            padding: 1rem 2rem;
-            cursor: pointer;
-            border: none;
-            background: none;
-            font-size: 1rem;
-            color: #6c757d;
-            border-bottom: 2px solid transparent;
-            transition: all 0.3s ease;
-        }
-        
-        .tab.active {
-            color: #5cb85c;
-            border-bottom-color: #5cb85c;
-        }
-        
-        .tab:hover {
-            color: #5cb85c;
-        }
-        
-        .tab-content {
-            display: none;
-        }
-        
-        .tab-content.active {
-            display: block;
-        }
-        
-        /* Stili Form */
-        .patient-info {
-            background: #f8f9fa;
-            padding: 1.5rem;
-            border-radius: 8px;
-            margin-bottom: 2rem;
-        }
-        
-        .patient-info h4 {
-            color: #5cb85c;
-            margin-bottom: 1rem;
-        }
-        
-        .patient-info input {
-            width: 100%;
-            padding: 0.5rem;
-            border: 1px solid #dee2e6;
-            border-radius: 4px;
-            margin-bottom: 1rem;
-        }
-        
-        .form-group {
-            margin-bottom: 1.5rem;
-            padding: 1rem;
-            background: #f8f9fa;
-            border-radius: 8px;
-        }
-        
-        .form-group h4 {
-            color: #5cb85c;
-            margin-bottom: 1rem;
-        }
-        
-        .form-item {
-            margin-bottom: 1.5rem;
-            padding: 1rem;
-            background: white;
-            border-radius: 8px;
-            border-left: 4px solid #dee2e6;
-        }
-        
-        .form-item.completed {
-            border-left-color: #28a745;
-        }
-        
-        .form-item label {
-            display: block;
-            font-weight: 600;
-            margin-bottom: 0.5rem;
-            color: #495057;
-        }
-        
-        .radio-group {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 1rem;
-            margin-top: 0.5rem;
-        }
-        
-        .radio-option {
-            display: flex;
-            align-items: center;
-            cursor: pointer;
-            padding: 0.5rem 1rem;
-            border: 2px solid #dee2e6;
-            border-radius: 25px;
-            transition: all 0.3s ease;
-            min-width: 150px;
-        }
-        
-        .radio-option:hover {
-            border-color: #5cb85c;
-            background: #f0f7ff;
-        }
-        
-        .radio-option.selected {
-            border-color: #28a745;
-            background: #d4edda;
-            color: #155724;
-        }
-        
-        .radio-option input[type="radio"] {
-            margin-right: 0.5rem;
-        }
-        
-        .score-display {
-            background: linear-gradient(135deg, #5cb85c, #449d44);
-            color: white;
-            padding: 2rem;
-            border-radius: 12px;
-            text-align: center;
-            margin: 2rem 0;
-        }
-        
-        .score-number {
-            font-size: 3rem;
-            font-weight: bold;
-            margin-bottom: 0.5rem;
-        }
-        
-        .score-interpretation {
-            font-size: 1.2rem;
-            margin-bottom: 1rem;
-        }
-        
-        .score-description {
-            font-size: 1rem;
-            opacity: 0.9;
-        }
-        
-        /* Tabelle di riferimento */
-        .scale-table {
-            width: 100%;
-            border-collapse: collapse;
-            margin: 1rem 0;
-            font-size: 0.9rem;
-        }
-        
-        .scale-table th,
-        .scale-table td {
-            border: 1px solid #dee2e6;
-            padding: 0.75rem;
-            text-align: left;
-        }
-        
-        .scale-table th {
-            background-color: #f8f9fa;
-            font-weight: 600;
-            color: #495057;
-        }
-        
-        .scale-table tbody tr:nth-child(even) {
-            background-color: #f8f9fa;
-        }
-        
-        /* Bottoni */
-        .btn {
-            padding: 0.75rem 2rem;
-            border: none;
-            border-radius: 6px;
-            cursor: pointer;
-            font-size: 1rem;
-            transition: all 0.3s ease;
-            margin: 0.5rem;
-        }
-        
-        .btn-success {
-            background: #28a745;
-            color: white;
-        }
-        
-        .btn-success:hover {
-            background: #218838;
-        }
-        
-        .reset-btn {
-            background: #dc3545;
-            color: white;
-        }
-        
-        .reset-btn:hover {
-            background: #c82333;
-        }
-
-        .progress-bar {
-            background: #e9ecef;
-            border-radius: 10px;
-            height: 8px;
-            margin: 1rem 0;
-        }
-
-        .progress-fill {
-            background: linear-gradient(90deg, #28a745, #20c997);
-            height: 100%;
-            border-radius: 10px;
-            transition: width 0.3s ease;
-        }
-        
-        /* Responsive */
-        @media (max-width: 768px) {
-            .prognosi-grid {
-                grid-template-columns: 1fr;
-            }
-            
-            .modal-content {
-                width: 98%;
-                margin: 1% auto;
-                padding: 1rem;
-            }
-            
-            .tabs {
-                flex-wrap: wrap;
-            }
-            
-            .tab {
-                padding: 0.75rem 1rem;
-                font-size: 0.9rem;
-            }
-            
-            .radio-group {
-                flex-direction: column;
-            }
-            
-            .radio-option {
-                min-width: auto;
-            }
-        }
-    </style>
-</head>
-<body>
-    <div class="prognosi-container">
-        <h1 style="color: #5cb85c; text-align: center; margin-bottom: 1rem;">Strumenti di Prognosi</h1>
-        <p style="text-align: center; color: #666; margin-bottom: 2rem;">Scale prognostiche validate per la valutazione dell'aspettativa di vita in cure palliative</p>
-        
-        <div class="prognosi-grid">
-            <div class="prognosi-card ppi" onclick="openModal('ppi')">
-                <div class="card-header">
-                    <div class="card-icon">PPI</div>
-                    <div>
-                        <div class="card-title">PPI</div>
-                        <div class="card-subtitle">Palliative Performance Index</div>
-                    </div>
-                </div>
-                <div class="card-description">
-                    Strumento prognostico per stimare la sopravvivenza nei pazienti in cure palliative, basato su 5 parametri clinici facilmente valutabili.
-                </div>
-                <ul class="card-features">
-                    <li>5 parametri di valutazione</li>
-                    <li>Predizione sopravvivenza a 3 e 6 settimane</li>
-                    <li>Calcolo automatico del punteggio</li>
-                    <li>Validato internazionalmente</li>
-                </ul>
-                <div class="card-footer">
-                    Clicca per compilare la scala
-                </div>
-            </div>
-
-            <div class="prognosi-card pap" onclick="openModal('pap')">
-                <div class="card-header">
-                    <div class="card-icon">PaP</div>
-                    <div>
-                        <div class="card-title">PaP Score</div>
-                        <div class="card-subtitle">Palliative Prognostic Score</div>
-                    </div>
-                </div>
-                <div class="card-description">
-                    Score prognostico multidimensionale che combina valutazione clinica e parametri laboratoristici per predire la sopravvivenza a 30 giorni.
-                </div>
-                <ul class="card-features">
-                    <li>6 parametri clinici e laboratoristici</li>
-                    <li>3 gruppi di rischio prognostico (A/B/C)</li>
-                    <li>Predizione sopravvivenza a 30 giorni</li>
-                    <li>Ampiamente utilizzato in letteratura</li>
-                </ul>
-                <div class="card-footer">
-                    Clicca per compilare la scala
-                </div>
-            </div>
+<?php
+// strumenti-prognosi.php
+?>
+<section id="prognosi-home" class="sintomo-section p-4" data-sintomo="prognosi-home" style="display:none;">
+  <div class="prognosi-container">
+    <h5 class="mb-3"><i class="fas fa-chart-line me-2"></i>Strumenti di Prognosi</h5>
+    <p class="text-muted">Scale prognostiche validate per la valutazione dell'aspettativa di vita in cure palliative</p>
+    <div class="prognosi-grid">
+      <div class="prognosi-card ppi" onclick="openProgModal('ppi')">
+        <div class="card-header">
+          <div class="card-icon">PPI</div>
+          <div>
+            <div class="card-title">PPI</div>
+            <div class="card-subtitle">Palliative Performance Index</div>
+          </div>
         </div>
-    </div>
-
-    <!-- Modal PPI -->
-    <div id="modal-ppi" class="modal">
-        <div class="modal-content">
-            <span class="close" onclick="closeModal('ppi')">&times;</span>
-            <h3>PPI - Palliative Performance Index</h3>
-            
-            <div class="tabs">
-                <button class="tab active" onclick="showTab('ppi', 'compile')">📝 Compila</button>
-                <button class="tab" onclick="showTab('ppi', 'view')">📊 Visualizza Scala</button>
-            </div>
-
-            <!-- Tab Compila PPI -->
-            <div id="ppi-compile" class="tab-content active">
-                <div class="patient-info">
-                    <h4>Dati Paziente</h4>
-                    <input type="text" id="ppi-patient-name" placeholder="Nome paziente" />
-                    <input type="date" id="ppi-date" />
-                </div>
-
-                <div class="form-group">
-                    <h4>Compila i 5 parametri del PPI:</h4>
-                    <div style="margin-bottom: 1rem;">
-                        <div class="progress-bar">
-                            <div class="progress-fill" id="ppi-progress" style="width: 0%"></div>
-                        </div>
-                        <small style="color: #666;">Progresso: <span id="ppi-progress-text">0/5</span> parametri completati</small>
-                    </div>
-                    
-                    <div class="form-item" id="ppi-pps-item">
-                        <label>1. Palliative Performance Scale (PPS)</label>
-                        <div class="radio-group">
-                            <div class="radio-option" onclick="selectPPI('pps', 4)">
-                                <input type="radio" name="ppi-pps" value="4">
-                                <span>10-20% (4 punti)</span>
-                            </div>
-                            <div class="radio-option" onclick="selectPPI('pps', 2.5)">
-                                <input type="radio" name="ppi-pps" value="2.5">
-                                <span>30-50% (2.5 punti)</span>
-                            </div>
-                            <div class="radio-option" onclick="selectPPI('pps', 0)">
-                                <input type="radio" name="ppi-pps" value="0">
-                                <span>>60% (0 punti)</span>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="form-item" id="ppi-oral-item">
-                        <label>2. Assunzione orale</label>
-                        <div class="radio-group">
-                            <div class="radio-option" onclick="selectPPI('oral', 2.5)">
-                                <input type="radio" name="ppi-oral" value="2.5">
-                                <span>Severamente ridotta (2.5 punti)</span>
-                            </div>
-                            <div class="radio-option" onclick="selectPPI('oral', 1)">
-                                <input type="radio" name="ppi-oral" value="1">
-                                <span>Moderatamente ridotta (1 punto)</span>
-                            </div>
-                            <div class="radio-option" onclick="selectPPI('oral', 0)">
-                                <input type="radio" name="ppi-oral" value="0">
-                                <span>Normale (0 punti)</span>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="form-item" id="ppi-edema-item">
-                        <label>3. Edema</label>
-                        <div class="radio-group">
-                            <div class="radio-option" onclick="selectPPI('edema', 1)">
-                                <input type="radio" name="ppi-edema" value="1">
-                                <span>Presente (1 punto)</span>
-                            </div>
-                            <div class="radio-option" onclick="selectPPI('edema', 0)">
-                                <input type="radio" name="ppi-edema" value="0">
-                                <span>Assente (0 punti)</span>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="form-item" id="ppi-dyspnea-item">
-                        <label>4. Dispnea a riposo</label>
-                        <div class="radio-group">
-                            <div class="radio-option" onclick="selectPPI('dyspnea', 3.5)">
-                                <input type="radio" name="ppi-dyspnea" value="3.5">
-                                <span>Presente (3.5 punti)</span>
-                            </div>
-                            <div class="radio-option" onclick="selectPPI('dyspnea', 0)">
-                                <input type="radio" name="ppi-dyspnea" value="0">
-                                <span>Assente (0 punti)</span>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="form-item" id="ppi-delirium-item">
-                        <label>5. Delirium</label>
-                        <div class="radio-group">
-                            <div class="radio-option" onclick="selectPPI('delirium', 4)">
-                                <input type="radio" name="ppi-delirium" value="4">
-                                <span>Presente (4 punti)</span>
-                            </div>
-                            <div class="radio-option" onclick="selectPPI('delirium', 0)">
-                                <input type="radio" name="ppi-delirium" value="0">
-                                <span>Assente (0 punti)</span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <div id="ppi-results" class="score-display" style="display: none;">
-                    <div class="score-number" id="ppi-score">0</div>
-                    <div class="score-interpretation" id="ppi-interpretation">Punteggio PPI</div>
-                    <div class="score-description" id="ppi-description">Completa tutti i parametri per la valutazione prognostica</div>
-                </div>
-
-                <div style="text-align: center;">
-                    <button class="btn btn-success" onclick="generateReport('ppi')">📄 Genera Report</button>
-                    <button class="btn reset-btn" onclick="resetForm('ppi')">🔄 Azzera</button>
-                </div>
-            </div>
-
-            <!-- Tab Visualizza Scala PPI -->
-            <div id="ppi-view" class="tab-content">
-                <h4>Palliative Performance Index (PPI)</h4>
-                <table class="scale-table">
-                    <thead>
-                        <tr>
-                            <th>Parametro</th>
-                            <th>Valore</th>
-                            <th>Punteggio</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr><td rowspan="3"><strong>Palliative Performance Scale</strong></td><td>10-20%</td><td>4.0</td></tr>
-                        <tr><td>30-50%</td><td>2.5</td></tr>
-                        <tr><td>>60%</td><td>0</td></tr>
-                        <tr><td rowspan="3"><strong>Assunzione orale</strong></td><td>Severamente ridotta</td><td>2.5</td></tr>
-                        <tr><td>Moderatamente ridotta</td><td>1.0</td></tr>
-                        <tr><td>Normale</td><td>0</td></tr>
-                        <tr><td rowspan="2"><strong>Edema</strong></td><td>Presente</td><td>1.0</td></tr>
-                        <tr><td>Assente</td><td>0</td></tr>
-                        <tr><td rowspan="2"><strong>Dispnea a riposo</strong></td><td>Presente</td><td>3.5</td></tr>
-                        <tr><td>Assente</td><td>0</td></tr>
-                        <tr><td rowspan="2"><strong>Delirium</strong></td><td>Presente</td><td>4.0</td></tr>
-                        <tr><td>Assente</td><td>0</td></tr>
-                    </tbody>
-                </table>
-                
-                <div style="background: #f8f9fa; padding: 1.5rem; border-radius: 8px; margin-top: 1.5rem;">
-                    <h5 style="color: #e74c3c; margin-bottom: 1rem;">📈 Interpretazione Prognostica:</h5>
-                    <ul style="margin: 0; padding-left: 1.5rem; color: #666;">
-                        <li><strong>PPI ≤ 4:</strong> Sopravvivenza >6 settimane (probabilità >70%)</li>
-                        <li><strong>PPI > 4:</strong> Sopravvivenza ≤3 settimane (probabilità >80%)</li>
-                        <li><strong>Punteggio totale:</strong> 0-15 punti</li>
-                        <li><strong>Maggiore è il punteggio, minore è la sopravvivenza attesa</strong></li>
-                    </ul>
-                </div>
-            </div>
+        <div class="card-description">
+          Strumento prognostico per stimare la sopravvivenza nei pazienti in cure palliative, basato su 5 parametri clinici facilmente valutabili.
         </div>
-    </div>
-
-    <!-- Modal PaP Score -->
-    <div id="modal-pap" class="modal">
-        <div class="modal-content">
-            <span class="close" onclick="closeModal('pap')">&times;</span>
-            <h3>PaP Score - Palliative Prognostic Score</h3>
-            
-            <div class="tabs">
-                <button class="tab active" onclick="showTab('pap', 'compile')">📝 Compila</button>
-                <button class="tab" onclick="showTab('pap', 'view')">📊 Visualizza Scala</button>
-            </div>
-
-            <!-- Tab Compila PaP -->
-            <div id="pap-compile" class="tab-content active">
-                <div class="patient-info">
-                    <h4>Dati Paziente</h4>
-                    <input type="text" id="pap-patient-name" placeholder="Nome paziente" />
-                    <input type="date" id="pap-date" />
-                </div>
-
-                <div class="form-group">
-                    <h4>Compila i 6 parametri del PaP Score:</h4>
-                    <div style="margin-bottom: 1rem;">
-                        <div class="progress-bar">
-                            <div class="progress-fill" id="pap-progress" style="width: 0%"></div>
-                        </div>
-                        <small style="color: #666;">Progresso: <span id="pap-progress-text">0/6</span> parametri completati</small>
-                    </div>
-                    
-                    <div class="form-item" id="pap-dyspnea-item">
-                        <label>1. Dispnea</label>
-                        <div class="radio-group">
-                            <div class="radio-option" onclick="selectPAP('dyspnea', 1)">
-                                <input type="radio" name="pap-dyspnea" value="1">
-                                <span>Sì (1 punto)</span>
-                            </div>
-                            <div class="radio-option" onclick="selectPAP('dyspnea', 0)">
-                                <input type="radio" name="pap-dyspnea" value="0">
-                                <span>No (0 punti)</span>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="form-item" id="pap-anorexia-item">
-                        <label>2. Anoressia</label>
-                        <div class="radio-group">
-                            <div class="radio-option" onclick="selectPAP('anorexia', 1)">
-                                <input type="radio" name="pap-anorexia" value="1">
-                                <span>Sì (1 punto)</span>
-                            </div>
-                            <div class="radio-option" onclick="selectPAP('anorexia', 0)">
-                                <input type="radio" name="pap-anorexia" value="0">
-                                <span>No (0 punti)</span>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="form-item" id="pap-karnofsky-item">
-                        <label>3. Karnofsky Performance Status</label>
-                        <div class="radio-group">
-                            <div class="radio-option" onclick="selectPAP('karnofsky', 2.5)">
-                                <input type="radio" name="pap-karnofsky" value="2.5">
-                                <span>10-20 (2.5 punti)</span>
-                            </div>
-                            <div class="radio-option" onclick="selectPAP('karnofsky', 0)">
-                                <input type="radio" name="pap-karnofsky" value="0">
-                                <span>30-100 (0 punti)</span>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="form-item" id="pap-wbc-item">
-                        <label>4. Leucociti totali</label>
-                        <div class="radio-group">
-                            <div class="radio-option" onclick="selectPAP('wbc', 1.5)">
-                                <input type="radio" name="pap-wbc" value="1.5">
-                                <span>>11.000 (1.5 punti)</span>
-                            </div>
-                            <div class="radio-option" onclick="selectPAP('wbc', 0.5)">
-                                <input type="radio" name="pap-wbc" value="0.5">
-                                <span>8.501-11.000 (0.5 punti)</span>
-                            </div>
-                            <div class="radio-option" onclick="selectPAP('wbc', 0)">
-                                <input type="radio" name="pap-wbc" value="0">
-                                <span>≤8.500 (0 punti)</span>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="form-item" id="pap-lymphocytes-item">
-                        <label>5. Percentuale Linfociti</label>
-                        <div class="radio-group">
-                            <div class="radio-option" onclick="selectPAP('lymphocytes', 2.5)">
-                                <input type="radio" name="pap-lymphocytes" value="2.5">
-                                <span>0-11.9% (2.5 punti)</span>
-                            </div>
-                            <div class="radio-option" onclick="selectPAP('lymphocytes', 1)">
-                                <input type="radio" name="pap-lymphocytes" value="1">
-                                <span>12-19.9% (1 punto)</span>
-                            </div>
-                            <div class="radio-option" onclick="selectPAP('lymphocytes', 0)">
-                                <input type="radio" name="pap-lymphocytes" value="0">
-                                <span>≥20% (0 punti)</span>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="form-item" id="pap-prediction-item">
-                        <label>6. Predizione clinica di sopravvivenza</label>
-                        <div class="radio-group">
-                            <div class="radio-option" onclick="selectPAP('prediction', 8.5)">
-                                <input type="radio" name="pap-prediction" value="8.5">
-                                <span>1-2 settimane (8.5 punti)</span>
-                            </div>
-                            <div class="radio-option" onclick="selectPAP('prediction', 6)">
-                                <input type="radio" name="pap-prediction" value="6">
-                                <span>3-4 settimane (6 punti)</span>
-                            </div>
-                            <div class="radio-option" onclick="selectPAP('prediction', 4.5)">
-                                <input type="radio" name="pap-prediction" value="4.5">
-                                <span>5-6 settimane (4.5 punti)</span>
-                            </div>
-                            <div class="radio-option" onclick="selectPAP('prediction', 2.5)">
-                                <input type="radio" name="pap-prediction" value="2.5">
-                                <span>7-10 settimane (2.5 punti)</span>
-                            </div>
-                            <div class="radio-option" onclick="selectPAP('prediction', 0)">
-                                <input type="radio" name="pap-prediction" value="0">
-                                <span>>10 settimane (0 punti)</span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <div id="pap-results" class="score-display" style="display: none;">
-                    <div class="score-number" id="pap-score">0</div>
-                    <div class="score-interpretation" id="pap-interpretation">Punteggio PaP</div>
-                    <div class="score-description" id="pap-description">Completa tutti i parametri per la valutazione prognostica</div>
-                </div>
-
-                <div style="text-align: center;">
-                    <button class="btn btn-success" onclick="generateReport('pap')">📄 Genera Report</button>
-                    <button class="btn reset-btn" onclick="resetForm('pap')">🔄 Azzera</button>
-                </div>
-            </div>
-
-            <!-- Tab Visualizza Scala PaP -->
-            <div id="pap-view" class="tab-content">
-                <h4>Palliative Prognostic Score (PaP)</h4>
-                <table class="scale-table">
-                    <thead>
-                        <tr>
-                            <th>Parametro</th>
-                            <th>Valore</th>
-                            <th>Punteggio</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr><td rowspan="2"><strong>Dispnea</strong></td><td>Sì</td><td>1.0</td></tr>
-                        <tr><td>No</td><td>0</td></tr>
-                        <tr><td rowspan="2"><strong>Anoressia</strong></td><td>Sì</td><td>1.0</td></tr>
-                        <tr><td>No</td><td>0</td></tr>
-                        <tr><td rowspan="2"><strong>Karnofsky Performance Status</strong></td><td>10-20</td><td>2.5</td></tr>
-                        <tr><td>30-100</td><td>0</td></tr>
-                        <tr><td rowspan="3"><strong>Leucociti totali</strong></td><td>>11.000</td><td>1.5</td></tr>
-                        <tr><td>8.501-11.000</td><td>0.5</td></tr>
-                        <tr><td>≤8.500</td><td>0</td></tr>
-                        <tr><td rowspan="3"><strong>% Linfociti</strong></td><td>0-11.9%</td><td>2.5</td></tr>
-                        <tr><td>12-19.9%</td><td>1.0</td></tr>
-                        <tr><td>≥20%</td><td>0</td></tr>
-                        <tr><td rowspan="5"><strong>Predizione clinica</strong></td><td>1-2 settimane</td><td>8.5</td></tr>
-                        <tr><td>3-4 settimane</td><td>6.0</td></tr>
-                        <tr><td>5-6 settimane</td><td>4.5</td></tr>
-                        <tr><td>7-10 settimane</td><td>2.5</td></tr>
-                        <tr><td>>10 settimane</td><td>0</td></tr>
-                    </tbody>
-                </table>
-                
-                <div style="background: #f8f9fa; padding: 1.5rem; border-radius: 8px; margin-top: 1.5rem;">
-                    <h5 style="color: #9b59b6; margin-bottom: 1rem;">📈 Interpretazione Prognostica:</h5>
-                    <ul style="margin: 0; padding-left: 1.5rem; color: #666;">
-                        <li><strong>Gruppo A (0-5.5 punti):</strong> Sopravvivenza >30 giorni (probabilità >70%)</li>
-                        <li><strong>Gruppo B (5.6-11 punti):</strong> Sopravvivenza incerta (30-70%)</li>
-                        <li><strong>Gruppo C (11.1-17.5 punti):</strong> Sopravvivenza <30 giorni (probabilità >70%)</li>
-                        <li><strong>Punteggio totale:</strong> 0-17.5 punti</li>
-                    </ul>
-                </div>
-            </div>
+      </div>
+      <div class="prognosi-card pap" onclick="openProgModal('pap')">
+        <div class="card-header">
+          <div class="card-icon">PaP</div>
+          <div>
+            <div class="card-title">PaP Score</div>
+            <div class="card-subtitle">Palliative Prognostic Score</div>
+          </div>
         </div>
+        <div class="card-description">
+          Score prognostico multidimensionale che combina valutazione clinica e parametri laboratoristici per predire la sopravvivenza a 30 giorni.
+        </div>
+      </div>
     </div>
+  </div>
+</section>
 
-    <script>
-        // Variabili globali per i punteggi
-        let ppiData = {
-            pps: null,
-            oral: null,
-            edema: null,
-            dyspnea: null,
-            delirium: null
-        };
+<!-- Modal PPI -->
+<div id="prog-modal-ppi" class="prog-modal">
+  <div class="prog-modal-content">
+    <span class="prog-close" onclick="closeProgModal('ppi')">&times;</span>
+    <h3>PPI - Palliative Performance Index</h3>
+    <div class="tabs">
+      <button class="tab active" onclick="showProgTab('ppi','compile')">📝 Compila</button>
+      <button class="tab" onclick="showProgTab('ppi','view')">📊 Visualizza Scala</button>
+    </div>
+    <div id="ppi-compile" class="tab-content active">
+      <div class="patient-info">
+        <h4>Dati Paziente</h4>
+        <input type="text" id="ppi-patient-name" placeholder="Nome paziente" />
+        <input type="date" id="ppi-date" />
+      </div>
+      <div class="form-group">
+        <h4>Compila i 5 parametri del PPI:</h4>
+        <div style="margin-bottom:1rem;">
+          <div class="progress-bar"><div class="progress-fill" id="ppi-progress" style="width:0%"></div></div>
+          <small style="color:#666;">Progresso: <span id="ppi-progress-text">0/5</span> parametri completati</small>
+        </div>
+        <div class="form-item" id="ppi-pps-item">
+          <label>1. Palliative Performance Scale (PPS)</label>
+          <div class="radio-group">
+            <div class="radio-option" onclick="selectPPI('pps',4)"><input type="radio" name="ppi-pps" value="4"><span>10-20% (4 punti)</span></div>
+            <div class="radio-option" onclick="selectPPI('pps',2.5)"><input type="radio" name="ppi-pps" value="2.5"><span>30-50% (2.5 punti)</span></div>
+            <div class="radio-option" onclick="selectPPI('pps',0)"><input type="radio" name="ppi-pps" value="0"><span>>60% (0 punti)</span></div>
+          </div>
+        </div>
+        <div class="form-item" id="ppi-oral-item">
+          <label>2. Assunzione orale</label>
+          <div class="radio-group">
+            <div class="radio-option" onclick="selectPPI('oral',2.5)"><input type="radio" name="ppi-oral" value="2.5"><span>Severamente ridotta (2.5 punti)</span></div>
+            <div class="radio-option" onclick="selectPPI('oral',1)"><input type="radio" name="ppi-oral" value="1"><span>Moderatamente ridotta (1 punto)</span></div>
+            <div class="radio-option" onclick="selectPPI('oral',0)"><input type="radio" name="ppi-oral" value="0"><span>Normale (0 punti)</span></div>
+          </div>
+        </div>
+        <div class="form-item" id="ppi-edema-item">
+          <label>3. Edema</label>
+          <div class="radio-group">
+            <div class="radio-option" onclick="selectPPI('edema',1)"><input type="radio" name="ppi-edema" value="1"><span>Presente (1 punto)</span></div>
+            <div class="radio-option" onclick="selectPPI('edema',0)"><input type="radio" name="ppi-edema" value="0"><span>Assente (0 punti)</span></div>
+          </div>
+        </div>
+        <div class="form-item" id="ppi-dyspnea-item">
+          <label>4. Dispnea a riposo</label>
+          <div class="radio-group">
+            <div class="radio-option" onclick="selectPPI('dyspnea',3.5)"><input type="radio" name="ppi-dyspnea" value="3.5"><span>Presente (3.5 punti)</span></div>
+            <div class="radio-option" onclick="selectPPI('dyspnea',0)"><input type="radio" name="ppi-dyspnea" value="0"><span>Assente (0 punti)</span></div>
+          </div>
+        </div>
+        <div class="form-item" id="ppi-delirium-item">
+          <label>5. Delirium</label>
+          <div class="radio-group">
+            <div class="radio-option" onclick="selectPPI('delirium',4)"><input type="radio" name="ppi-delirium" value="4"><span>Presente (4 punti)</span></div>
+            <div class="radio-option" onclick="selectPPI('delirium',0)"><input type="radio" name="ppi-delirium" value="0"><span>Assente (0 punti)</span></div>
+          </div>
+        </div>
+      </div>
+      <div id="ppi-results" class="score-display" style="display:none;">
+        <div class="score-number" id="ppi-score">0</div>
+        <div class="score-interpretation" id="ppi-interpretation">Punteggio PPI</div>
+        <div class="score-description" id="ppi-description">Completa tutti i parametri per la valutazione prognostica</div>
+      </div>
+      <div class="text-center">
+        <button class="btn btn-success" onclick="generateReport('ppi')">📄 Genera Report</button>
+        <button class="btn reset-btn" onclick="resetForm('ppi')">🔄 Azzera</button>
+      </div>
+    </div>
+    <div id="ppi-view" class="tab-content">
+      <h4>Palliative Performance Index (PPI)</h4>
+      <table class="scale-table">
+        <thead>
+          <tr><th>Parametro</th><th>Valore</th><th>Punteggio</th></tr>
+        </thead>
+        <tbody>
+          <tr><td rowspan="3"><strong>Palliative Performance Scale</strong></td><td>10-20%</td><td>4.0</td></tr>
+          <tr><td>30-50%</td><td>2.5</td></tr>
+          <tr><td>>60%</td><td>0</td></tr>
+          <tr><td rowspan="3"><strong>Assunzione orale</strong></td><td>Severamente ridotta</td><td>2.5</td></tr>
+          <tr><td>Moderatamente ridotta</td><td>1.0</td></tr>
+          <tr><td>Normale</td><td>0</td></tr>
+          <tr><td rowspan="2"><strong>Edema</strong></td><td>Presente</td><td>1.0</td></tr>
+          <tr><td>Assente</td><td>0</td></tr>
+          <tr><td rowspan="2"><strong>Dispnea a riposo</strong></td><td>Presente</td><td>3.5</td></tr>
+          <tr><td>Assente</td><td>0</td></tr>
+          <tr><td rowspan="2"><strong>Delirium</strong></td><td>Presente</td><td>4.0</td></tr>
+          <tr><td>Assente</td><td>0</td></tr>
+        </tbody>
+      </table>
+      <div style="background:#f8f9fa;padding:1.5rem;border-radius:8px;margin-top:1.5rem;">
+        <h5 style="color:#e74c3c;margin-bottom:1rem;">📈 Interpretazione Prognostica:</h5>
+        <ul style="margin:0;padding-left:1.5rem;color:#666;">
+          <li><strong>PPI ≤ 4:</strong> Sopravvivenza >6 settimane (probabilità >70%)</li>
+          <li><strong>PPI > 4:</strong> Sopravvivenza ≤3 settimane (probabilità >80%)</li>
+          <li><strong>Punteggio totale:</strong> 0-15 punti</li>
+          <li><strong>Maggiore è il punteggio, minore è la sopravvivenza attesa</strong></li>
+        </ul>
+      </div>
+      <div class="text-center mt-3"><button class="btn btn-primary" onclick="window.print()">Stampa</button></div>
+    </div>
+  </div>
+</div>
 
-        let papData = {
-            dyspnea: null,
-            anorexia: null,
-            karnofsky: null,
-            wbc: null,
-            lymphocytes: null,
-            prediction: null
-        };
+<!-- Modal PaP -->
+<div id="prog-modal-pap" class="prog-modal">
+  <div class="prog-modal-content">
+    <span class="prog-close" onclick="closeProgModal('pap')">&times;</span>
+    <h3>PaP Score - Palliative Prognostic Score</h3>
+    <div class="tabs">
+      <button class="tab active" onclick="showProgTab('pap','compile')">📝 Compila</button>
+      <button class="tab" onclick="showProgTab('pap','view')">📊 Visualizza Scala</button>
+    </div>
+    <div id="pap-compile" class="tab-content active">
+      <div class="patient-info">
+        <h4>Dati Paziente</h4>
+        <input type="text" id="pap-patient-name" placeholder="Nome paziente" />
+        <input type="date" id="pap-date" />
+      </div>
+      <div class="form-group">
+        <h4>Compila i 6 parametri del PaP Score:</h4>
+        <div style="margin-bottom:1rem;">
+          <div class="progress-bar"><div class="progress-fill" id="pap-progress" style="width:0%"></div></div>
+          <small style="color:#666;">Progresso: <span id="pap-progress-text">0/6</span> parametri completati</small>
+        </div>
+        <div class="form-item" id="pap-dyspnea-item">
+          <label>1. Dispnea</label>
+          <div class="radio-group">
+            <div class="radio-option" onclick="selectPAP('dyspnea',1)"><input type="radio" name="pap-dyspnea" value="1"><span>Sì (1 punto)</span></div>
+            <div class="radio-option" onclick="selectPAP('dyspnea',0)"><input type="radio" name="pap-dyspnea" value="0"><span>No (0 punti)</span></div>
+          </div>
+        </div>
+        <div class="form-item" id="pap-anorexia-item">
+          <label>2. Anoressia</label>
+          <div class="radio-group">
+            <div class="radio-option" onclick="selectPAP('anorexia',1)"><input type="radio" name="pap-anorexia" value="1"><span>Sì (1 punto)</span></div>
+            <div class="radio-option" onclick="selectPAP('anorexia',0)"><input type="radio" name="pap-anorexia" value="0"><span>No (0 punti)</span></div>
+          </div>
+        </div>
+        <div class="form-item" id="pap-karnofsky-item">
+          <label>3. Karnofsky Performance Status</label>
+          <div class="radio-group">
+            <div class="radio-option" onclick="selectPAP('karnofsky',2.5)"><input type="radio" name="pap-karnofsky" value="2.5"><span>10-20 (2.5 punti)</span></div>
+            <div class="radio-option" onclick="selectPAP('karnofsky',0)"><input type="radio" name="pap-karnofsky" value="0"><span>30-100 (0 punti)</span></div>
+          </div>
+        </div>
+        <div class="form-item" id="pap-wbc-item">
+          <label>4. Leucociti totali</label>
+          <div class="radio-group">
+            <div class="radio-option" onclick="selectPAP('wbc',1.5)"><input type="radio" name="pap-wbc" value="1.5"><span>>11.000 (1.5 punti)</span></div>
+            <div class="radio-option" onclick="selectPAP('wbc',0.5)"><input type="radio" name="pap-wbc" value="0.5"><span>8.501-11.000 (0.5 punti)</span></div>
+            <div class="radio-option" onclick="selectPAP('wbc',0)"><input type="radio" name="pap-wbc" value="0"><span>≤8.500 (0 punti)</span></div>
+          </div>
+        </div>
+        <div class="form-item" id="pap-lymphocytes-item">
+          <label>5. Percentuale Linfociti</label>
+          <div class="radio-group">
+            <div class="radio-option" onclick="selectPAP('lymphocytes',2.5)"><input type="radio" name="pap-lymphocytes" value="2.5"><span>0-11.9% (2.5 punti)</span></div>
+            <div class="radio-option" onclick="selectPAP('lymphocytes',1)"><input type="radio" name="pap-lymphocytes" value="1"><span>12-19.9% (1 punto)</span></div>
+            <div class="radio-option" onclick="selectPAP('lymphocytes',0)"><input type="radio" name="pap-lymphocytes" value="0"><span>≥20% (0 punti)</span></div>
+          </div>
+        </div>
+        <div class="form-item" id="pap-prediction-item">
+          <label>6. Predizione clinica di sopravvivenza</label>
+          <div class="radio-group">
+            <div class="radio-option" onclick="selectPAP('prediction',8.5)"><input type="radio" name="pap-prediction" value="8.5"><span>1-2 settimane (8.5 punti)</span></div>
+            <div class="radio-option" onclick="selectPAP('prediction',6)"><input type="radio" name="pap-prediction" value="6"><span>3-4 settimane (6 punti)</span></div>
+            <div class="radio-option" onclick="selectPAP('prediction',4.5)"><input type="radio" name="pap-prediction" value="4.5"><span>5-6 settimane (4.5 punti)</span></div>
+            <div class="radio-option" onclick="selectPAP('prediction',2.5)"><input type="radio" name="pap-prediction" value="2.5"><span>7-10 settimane (2.5 punti)</span></div>
+            <div class="radio-option" onclick="selectPAP('prediction',0)"><input type="radio" name="pap-prediction" value="0"><span>>10 settimane (0 punti)</span></div>
+          </div>
+        </div>
+      </div>
+      <div id="pap-results" class="score-display" style="display:none;">
+        <div class="score-number" id="pap-score">0</div>
+        <div class="score-interpretation" id="pap-interpretation">Punteggio PaP</div>
+        <div class="score-description" id="pap-description">Completa tutti i parametri per la valutazione prognostica</div>
+      </div>
+      <div class="text-center">
+        <button class="btn btn-success" onclick="generateReport('pap')">📄 Genera Report</button>
+        <button class="btn reset-btn" onclick="resetForm('pap')">🔄 Azzera</button>
+      </div>
+    </div>
+    <div id="pap-view" class="tab-content">
+      <h4>Palliative Prognostic Score (PaP)</h4>
+      <table class="scale-table">
+        <thead>
+          <tr><th>Parametro</th><th>Valore</th><th>Punteggio</th></tr>
+        </thead>
+        <tbody>
+          <tr><td rowspan="2"><strong>Dispnea</strong></td><td>Sì</td><td>1.0</td></tr>
+          <tr><td>No</td><td>0</td></tr>
+          <tr><td rowspan="2"><strong>Anoressia</strong></td><td>Sì</td><td>1.0</td></tr>
+          <tr><td>No</td><td>0</td></tr>
+          <tr><td rowspan="2"><strong>Karnofsky Performance Status</strong></td><td>10-20</td><td>2.5</td></tr>
+          <tr><td>30-100</td><td>0</td></tr>
+          <tr><td rowspan="3"><strong>Leucociti totali</strong></td><td>>11.000</td><td>1.5</td></tr>
+          <tr><td>8.501-11.000</td><td>0.5</td></tr>
+          <tr><td>≤8.500</td><td>0</td></tr>
+          <tr><td rowspan="3"><strong>% Linfociti</strong></td><td>0-11.9%</td><td>2.5</td></tr>
+          <tr><td>12-19.9%</td><td>1.0</td></tr>
+          <tr><td>≥20%</td><td>0</td></tr>
+          <tr><td rowspan="5"><strong>Predizione clinica</strong></td><td>1-2 settimane</td><td>8.5</td></tr>
+          <tr><td>3-4 settimane</td><td>6.0</td></tr>
+          <tr><td>5-6 settimane</td><td>4.5</td></tr>
+          <tr><td>7-10 settimane</td><td>2.5</td></tr>
+          <tr><td>>10 settimane</td><td>0</td></tr>
+        </tbody>
+      </table>
+      <div style="background:#f8f9fa;padding:1.5rem;border-radius:8px;margin-top:1.5rem;">
+        <h5 style="color:#9b59b6;margin-bottom:1rem;">📈 Interpretazione Prognostica:</h5>
+        <ul style="margin:0;padding-left:1.5rem;color:#666;">
+          <li><strong>Gruppo A (0-5.5 punti):</strong> Sopravvivenza >30 giorni (probabilità >70%)</li>
+          <li><strong>Gruppo B (5.6-11 punti):</strong> Sopravvivenza incerta (30-70%)</li>
+          <li><strong>Gruppo C (11.1-17.5 punti):</strong> Sopravvivenza <30 giorni (probabilità >70%)</li>
+          <li><strong>Punteggio totale:</strong> 0-17.5 punti</li>
+        </ul>
+      </div>
+      <div class="text-center mt-3"><button class="btn btn-primary" onclick="window.print()">Stampa</button></div>
+    </div>
+  </div>
+</div>
 
-        // Funzioni per aprire/chiudere modal
-        function openModal(type) {
-            document.getElementById(`modal-${type}`).style.display = 'block';
-            document.getElementById(`${type}-date`).value = new Date().toISOString().split('T')[0];
-        }
+<script>
+let ppiData={pps:null,oral:null,edema:null,dyspnea:null,delirium:null};
+let papData={dyspnea:null,anorexia:null,karnofsky:null,wbc:null,lymphocytes:null,prediction:null};
+function openProgModal(type){const m=document.getElementById('prog-modal-'+type);if(m){m.style.display='block';document.body.style.overflow='hidden';const dateInput=document.getElementById(type+'-date');if(dateInput&&!dateInput.value){dateInput.value=new Date().toISOString().split('T')[0];}}}
+function closeProgModal(type){const m=document.getElementById('prog-modal-'+type);if(m){m.style.display='none';document.body.style.overflow='auto';}}
+function showProgTab(scale,tab){const modal=document.getElementById('prog-modal-'+scale);modal.querySelectorAll('.tab-content').forEach(c=>c.classList.remove('active'));modal.querySelectorAll('.tab').forEach(t=>t.classList.remove('active'));modal.querySelector('#'+scale+'-'+tab).classList.add('active');event.target.classList.add('active');}
+function selectPPI(parameter,value){const radioGroup=event.target.closest('.radio-group');radioGroup.querySelectorAll('.radio-option').forEach(o=>{o.classList.remove('selected');o.querySelector('input').checked=false;});const option=event.target.closest('.radio-option');option.classList.add('selected');option.querySelector('input').checked=true;ppiData[parameter]=parseFloat(value);document.getElementById('ppi-'+parameter+'-item').classList.add('completed');updatePPIProgress();calculatePPI();}
+function selectPAP(parameter,value){const radioGroup=event.target.closest('.radio-group');radioGroup.querySelectorAll('.radio-option').forEach(o=>{o.classList.remove('selected');o.querySelector('input').checked=false;});const option=event.target.closest('.radio-option');option.classList.add('selected');option.querySelector('input').checked=true;papData[parameter]=parseFloat(value);document.getElementById('pap-'+parameter+'-item').classList.add('completed');updatePAPProgress();calculatePAP();}
+function updatePPIProgress(){const completed=Object.values(ppiData).filter(v=>v!==null).length;const total=Object.keys(ppiData).length;const perc=(completed/total)*100;document.getElementById('ppi-progress').style.width=perc+'%';document.getElementById('ppi-progress-text').textContent=`${completed}/${total}`;}
+function updatePAPProgress(){const completed=Object.values(papData).filter(v=>v!==null).length;const total=Object.keys(papData).length;const perc=(completed/total)*100;document.getElementById('pap-progress').style.width=perc+'%';document.getElementById('pap-progress-text').textContent=`${completed}/${total}`;}
+function calculatePPI(){const completed=Object.values(ppiData).filter(v=>v!==null).length;if(completed===Object.keys(ppiData).length){const total=Object.values(ppiData).reduce((s,v)=>s+v,0);let interp='',desc='';if(total<=4){interp='Buona prognosi';desc='Sopravvivenza >6 settimane (probabilità >70%)';}else{interp='Prognosi riservata';desc='Sopravvivenza ≤3 settimane (probabilità >80%)';}document.getElementById('ppi-score').textContent=total.toFixed(1);document.getElementById('ppi-interpretation').textContent=interp;document.getElementById('ppi-description').textContent=desc;document.getElementById('ppi-results').style.display='block';}else{document.getElementById('ppi-results').style.display='none';}}
+function calculatePAP(){const completed=Object.values(papData).filter(v=>v!==null).length;if(completed===Object.keys(papData).length){const total=Object.values(papData).reduce((s,v)=>s+v,0);let interp='',desc='',group='';if(total<=5.5){group='A';interp='Buona prognosi';desc='Sopravvivenza >30 giorni (probabilità >70%)';}else if(total<=11){group='B';interp='Prognosi intermedia';desc='Sopravvivenza incerta (30-70% probabilità)';}else{group='C';interp='Prognosi riservata';desc='Sopravvivenza <30 giorni (probabilità >70%)';}document.getElementById('pap-score').textContent=total.toFixed(1);document.getElementById('pap-interpretation').textContent=`Gruppo ${group} - ${interp}`;document.getElementById('pap-description').textContent=desc;document.getElementById('pap-results').style.display='block';}else{document.getElementById('pap-results').style.display='none';}}
+function resetForm(type){if(confirm('Sei sicuro di voler azzerare tutti i dati?')){if(type==='ppi'){ppiData={pps:null,oral:null,edema:null,dyspnea:null,delirium:null};document.getElementById('ppi-patient-name').value='';updatePPIProgress();document.getElementById('ppi-results').style.display='none';}else{papData={dyspnea:null,anorexia:null,karnofsky:null,wbc:null,lymphocytes:null,prediction:null};document.getElementById('pap-patient-name').value='';updatePAPProgress();document.getElementById('pap-results').style.display='none';}document.querySelectorAll(`#prog-modal-${type} .radio-option`).forEach(o=>{o.classList.remove('selected');o.querySelector('input').checked=false;});document.querySelectorAll(`#prog-modal-${type} .form-item`).forEach(i=>i.classList.remove('completed'));}}
+function generateReport(type){const patientName=document.getElementById(`${type}-patient-name`).value||'Paziente non specificato';const date=document.getElementById(`${type}-date`).value||new Date().toISOString().split('T')[0];let content='';if(type==='ppi'){const completed=Object.values(ppiData).filter(v=>v!==null).length;if(completed<Object.keys(ppiData).length){alert('Completa tutti i parametri prima di generare il report');return;}const total=Object.values(ppiData).reduce((s,v)=>s+v,0);content=`REPORT PPI - PALLIATIVE PERFORMANCE INDEX\n==========================================\n\nPaziente: ${patientName}\nData valutazione: ${new Date(date).toLocaleDateString('it-IT')}\n\nPARAMETRI VALUTATI:\n• Palliative Performance Scale: ${ppiData.pps} punti\n• Assunzione orale: ${ppiData.oral} punti\n• Edema: ${ppiData.edema} punti\n• Dispnea a riposo: ${ppiData.dyspnea} punti\n• Delirium: ${ppiData.delirium} punti\n\nPUNTEGGIO TOTALE: ${total.toFixed(1)} punti\n\nINTERPRETAZIONE:\n${total<=4?'Buona prognosi - Sopravvivenza >6 settimane (probabilità >70%)':'Prognosi riservata - Sopravvivenza ≤3 settimane (probabilità >80%)'}\n\nValutato da: [Nome del medico]\nFirma: ____________________\n`; } else {const completed=Object.values(papData).filter(v=>v!==null).length;if(completed<Object.keys(papData).length){alert('Completa tutti i parametri prima di generare il report');return;}const total=Object.values(papData).reduce((s,v)=>s+v,0);let group=total<=5.5?'A':total<=11?'B':'C';content=`REPORT PAP SCORE - PALLIATIVE PROGNOSTIC SCORE\n==============================================\n\nPaziente: ${patientName}\nData valutazione: ${new Date(date).toLocaleDateString('it-IT')}\n\nPARAMETRI VALUTATI:\n• Dispnea: ${papData.dyspnea} punti\n• Anoressia: ${papData.anorexia} punti\n• Karnofsky Performance Status: ${papData.karnofsky} punti\n• Leucociti totali: ${papData.wbc} punti\n• Percentuale Linfociti: ${papData.lymphocytes} punti\n• Predizione clinica: ${papData.prediction} punti\n\nPUNTEGGIO TOTALE: ${total.toFixed(1)} punti\nGRUPPO PROGNOSTICO: ${group}\n\nINTERPRETAZIONE:\n${group==='A'?'Buona prognosi - Sopravvivenza >30 giorni (probabilità >70%)':group==='B'?'Prognosi intermedia - Sopravvivenza incerta (30-70% probabilità)':'Prognosi riservata - Sopravvivenza <30 giorni (probabilità >70%)'}\n\nValutato da: [Nome del medico]\nFirma: ____________________\n`; }
+const blob=new Blob([content],{type:'text/plain;charset=utf-8'});const url=URL.createObjectURL(blob);const a=document.createElement('a');a.href=url;a.download=`Report_${type.toUpperCase()}_${patientName.replace(/\s+/g,'_')}_${date}.txt`;document.body.appendChild(a);a.click();document.body.removeChild(a);URL.revokeObjectURL(url);}
+window.onclick=function(e){if(e.target.classList.contains('prog-modal')){e.target.style.display='none';document.body.style.overflow='auto';}};
+document.addEventListener('keydown',function(e){if(e.key==='Escape'){document.querySelectorAll('.prog-modal').forEach(m=>m.style.display='none');document.body.style.overflow='auto';}});
+document.addEventListener('DOMContentLoaded',function(){const today=new Date().toISOString().split('T')[0];const ppiDate=document.getElementById('ppi-date');if(ppiDate)ppiDate.value=today;const papDate=document.getElementById('pap-date');if(papDate)papDate.value=today;});
+</script>
 
-        function closeModal(type) {
-            document.getElementById(`modal-${type}`).style.display = 'none';
-        }
-
-        // Funzione per gestire i tab
-        function showTab(scale, tab) {
-            const tabContents = document.querySelectorAll(`#modal-${scale} .tab-content`);
-            tabContents.forEach(content => content.classList.remove('active'));
-            const tabs = document.querySelectorAll(`#modal-${scale} .tab`);
-            tabs.forEach(t => t.classList.remove('active'));
-            document.getElementById(`${scale}-${tab}`).classList.add('active');
-            event.target.classList.add('active');
-        }
-
-        // Funzione per selezionare opzioni PPI
-        function selectPPI(parameter, value) {
-            const radioGroup = event.target.closest('.radio-group');
-            radioGroup.querySelectorAll('.radio-option').forEach(option => {
-                option.classList.remove('selected');
-                option.querySelector('input').checked = false;
-            });
-            event.target.closest('.radio-option').classList.add('selected');
-            event.target.closest('.radio-option').querySelector('input').checked = true;
-            ppiData[parameter] = parseFloat(value);
-            document.getElementById(`ppi-${parameter}-item`).classList.add('completed');
-            updatePPIProgress();
-            calculatePPI();
-        }
-
-        // Funzione per selezionare opzioni PaP
-        function selectPAP(parameter, value) {
-            const radioGroup = event.target.closest('.radio-group');
-            radioGroup.querySelectorAll('.radio-option').forEach(option => {
-                option.classList.remove('selected');
-                option.querySelector('input').checked = false;
-            });
-            event.target.closest('.radio-option').classList.add('selected');
-            event.target.closest('.radio-option').querySelector('input').checked = true;
-            papData[parameter] = parseFloat(value);
-            document.getElementById(`pap-${parameter}-item`).classList.add('completed');
-            updatePAPProgress();
-            calculatePAP();
-        }
-
-        // Aggiorna il progresso PPI
-        function updatePPIProgress() {
-            const completed = Object.values(ppiData).filter(val => val !== null).length;
-            const total = Object.keys(ppiData).length;
-            const percentage = (completed / total) * 100;
-            document.getElementById('ppi-progress').style.width = percentage + '%';
-            document.getElementById('ppi-progress-text').textContent = `${completed}/${total}`;
-        }
-
-        // Aggiorna il progresso PaP
-        function updatePAPProgress() {
-            const completed = Object.values(papData).filter(val => val !== null).length;
-            const total = Object.keys(papData).length;
-            const percentage = (completed / total) * 100;
-            document.getElementById('pap-progress').style.width = percentage + '%';
-            document.getElementById('pap-progress-text').textContent = `${completed}/${total}`;
-        }
-
-        // Calcola il punteggio PPI
-        function calculatePPI() {
-            const completed = Object.values(ppiData).filter(val => val !== null).length;
-            if (completed === Object.keys(ppiData).length) {
-                const totalScore = Object.values(ppiData).reduce((sum, val) => sum + val, 0);
-                let interpretation = '';
-                let description = '';
-                if (totalScore <= 4) {
-                    interpretation = 'Buona prognosi';
-                    description = 'Sopravvivenza >6 settimane (probabilità >70%)';
-                } else {
-                    interpretation = 'Prognosi riservata';
-                    description = 'Sopravvivenza ≤3 settimane (probabilità >80%)';
-                }
-                document.getElementById('ppi-score').textContent = totalScore.toFixed(1);
-                document.getElementById('ppi-interpretation').textContent = interpretation;
-                document.getElementById('ppi-description').textContent = description;
-                document.getElementById('ppi-results').style.display = 'block';
-            } else {
-                document.getElementById('ppi-results').style.display = 'none';
-            }
-        }
-
-        // Calcola il punteggio PaP
-        function calculatePAP() {
-            const completed = Object.values(papData).filter(val => val !== null).length;
-            if (completed === Object.keys(papData).length) {
-                const totalScore = Object.values(papData).reduce((sum, val) => sum + val, 0);
-                let interpretation = '';
-                let description = '';
-                let group = '';
-                if (totalScore <= 5.5) {
-                    group = 'A';
-                    interpretation = 'Buona prognosi';
-                    description = 'Sopravvivenza >30 giorni (probabilità >70%)';
-                } else if (totalScore <= 11) {
-                    group = 'B';
-                    interpretation = 'Prognosi intermedia';
-                    description = 'Sopravvivenza incerta (30-70% probabilità)';
-                } else {
-                    group = 'C';
-                    interpretation = 'Prognosi riservata';
-                    description = 'Sopravvivenza <30 giorni (probabilità >70%)';
-                }
-                document.getElementById('pap-score').textContent = totalScore.toFixed(1);
-                document.getElementById('pap-interpretation').textContent = `Gruppo ${group} - ${interpretation}`;
-                document.getElementById('pap-description').textContent = description;
-                document.getElementById('pap-results').style.display = 'block';
-            } else {
-                document.getElementById('pap-results').style.display = 'none';
-            }
-        }
-
-        // Reset del form
-        function resetForm(type) {
-            if (confirm('Sei sicuro di voler azzerare tutti i dati?')) {
-                if (type === 'ppi') {
-                    ppiData = { pps: null, oral: null, edema: null, dyspnea: null, delirium: null };
-                    document.getElementById('ppi-patient-name').value = '';
-                    updatePPIProgress();
-                    document.getElementById('ppi-results').style.display = 'none';
-                } else {
-                    papData = { dyspnea: null, anorexia: null, karnofsky: null, wbc: null, lymphocytes: null, prediction: null };
-                    document.getElementById('pap-patient-name').value = '';
-                    updatePAPProgress();
-                    document.getElementById('pap-results').style.display = 'none';
-                }
-                document.querySelectorAll(`#modal-${type} .radio-option`).forEach(option => {
-                    option.classList.remove('selected');
-                    option.querySelector('input').checked = false;
-                });
-                document.querySelectorAll(`#modal-${type} .form-item`).forEach(item => {
-                    item.classList.remove('completed');
-                });
-            }
-        }
-
-        // Genera report
-        function generateReport(type) {
-            const patientName = document.getElementById(`${type}-patient-name`).value || 'Paziente non specificato';
-            const date = document.getElementById(`${type}-date`).value || new Date().toISOString().split('T')[0];
-            let reportContent = '';
-            if (type === 'ppi') {
-                const completed = Object.values(ppiData).filter(val => val !== null).length;
-                if (completed < Object.keys(ppiData).length) {
-                    alert('Completa tutti i parametri prima di generare il report');
-                    return;
-                }
-                const totalScore = Object.values(ppiData).reduce((sum, val) => sum + val, 0);
-                reportContent = `\nREPORT PPI - PALLIATIVE PERFORMANCE INDEX\n==========================================\n\nPaziente: ${patientName}\nData valutazione: ${new Date(date).toLocaleDateString('it-IT')}\n\nPARAMETRI VALUTATI:\n• Palliative Performance Scale: ${ppiData.pps} punti\n• Assunzione orale: ${ppiData.oral} punti  \n• Edema: ${ppiData.edema} punti\n• Dispnea a riposo: ${ppiData.dyspnea} punti\n• Delirium: ${ppiData.delirium} punti\n\nPUNTEGGIO TOTALE: ${totalScore.toFixed(1)} punti\n\nINTERPRETAZIONE:\n${totalScore <= 4 ? 'Buona prognosi - Sopravvivenza >6 settimane (probabilità >70%)' : 'Prognosi riservata - Sopravvivenza ≤3 settimane (probabilità >80%)'}\n\nValutato da: [Nome del medico]\nFirma: ____________________\n                `;
-            } else {
-                const completed = Object.values(papData).filter(val => val !== null).length;
-                if (completed < Object.keys(papData).length) {
-                    alert('Completa tutti i parametri prima di generare il report');
-                    return;
-                }
-                const totalScore = Object.values(papData).reduce((sum, val) => sum + val, 0);
-                let group = totalScore <= 5.5 ? 'A' : totalScore <= 11 ? 'B' : 'C';
-                reportContent = `\nREPORT PAP SCORE - PALLIATIVE PROGNOSTIC SCORE\n==============================================\n\nPaziente: ${patientName}\nData valutazione: ${new Date(date).toLocaleDateString('it-IT')}\n\nPARAMETRI VALUTATI:\n• Dispnea: ${papData.dyspnea} punti\n• Anoressia: ${papData.anorexia} punti\n• Karnofsky Performance Status: ${papData.karnofsky} punti\n• Leucociti totali: ${papData.wbc} punti\n• Percentuale Linfociti: ${papData.lymphocytes} punti\n• Predizione clinica: ${papData.prediction} punti\n\nPUNTEGGIO TOTALE: ${totalScore.toFixed(1)} punti\nGRUPPO PROGNOSTICO: ${group}\n\nINTERPRETAZIONE:\n${group === 'A' ? 'Buona prognosi - Sopravvivenza >30 giorni (probabilità >70%)' : group === 'B' ? 'Prognosi intermedia - Sopravvivenza incerta (30-70% probabilità)' : 'Prognosi riservata - Sopravvivenza <30 giorni (probabilità >70%)'}\n\nValutato da: [Nome del medico]\nFirma: ____________________\n                `;
-            }
-            const blob = new Blob([reportContent], { type: 'text/plain;charset=utf-8' });
-            const url = URL.createObjectURL(blob);
-            const a = document.createElement('a');
-            a.href = url;
-            a.download = `Report_${type.toUpperCase()}_${patientName.replace(/\s+/g, '_')}_${date}.txt`;
-            document.body.appendChild(a);
-            a.click();
-            document.body.removeChild(a);
-            URL.revokeObjectURL(url);
-        }
-
-        // Chiudi modal cliccando fuori
-        window.onclick = function(event) {
-            if (event.target.classList.contains('modal')) {
-                event.target.style.display = 'none';
-            }
-        }
-
-        // Imposta la data di oggi e apertura modale da query
-        document.addEventListener('DOMContentLoaded', function() {
-            const today = new Date().toISOString().split('T')[0];
-            document.getElementById('ppi-date').value = today;
-            document.getElementById('pap-date').value = today;
-            const params = new URLSearchParams(window.location.search);
-            const scale = params.get('scale');
-            if(scale === 'ppi' || scale === 'pap') {
-                openModal(scale);
-            }
-        });
-    </script>
-</body>
-</html>
+<style>
+.prognosi-container{max-width:1200px;margin:0 auto;padding:2rem 1rem;}
+.prognosi-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:2rem;margin-top:2rem;}
+.prognosi-card{background:white;border-radius:12px;box-shadow:0 4px 20px rgba(0,0,0,0.08);padding:2rem;transition:all 0.3s ease;border:1px solid #e9ecef;cursor:pointer;}
+.prognosi-card:hover{transform:translateY(-5px);box-shadow:0 8px 30px rgba(0,0,0,0.15);border-color:#5cb85c;}
+.card-header{display:flex;align-items:center;margin-bottom:1.5rem;}
+.card-icon{width:50px;height:50px;border-radius:10px;display:flex;align-items:center;justify-content:center;font-size:1.5rem;color:white;margin-right:1rem;font-weight:bold;}
+.ppi .card-icon{background:linear-gradient(135deg,#e74c3c,#c0392b);} .pap .card-icon{background:linear-gradient(135deg,#9b59b6,#8e44ad);}
+.card-title{font-size:1.4rem;font-weight:600;color:#5cb85c;margin-bottom:0.3rem;}
+.card-subtitle{font-size:0.9rem;color:#6c757d;font-weight:500;}
+.card-description{color:#555;margin-bottom:1.5rem;font-size:0.95rem;}
+.prog-modal{display:none;position:fixed;z-index:1000;left:0;top:0;width:100%;height:100%;background-color:rgba(0,0,0,0.5);}
+.prog-modal-content{background-color:white;margin:2% auto;padding:2rem;border-radius:12px;width:95%;max-width:900px;max-height:90vh;overflow-y:auto;position:relative;}
+.prog-close{position:absolute;right:1rem;top:1rem;font-size:2rem;font-weight:bold;cursor:pointer;color:#aaa;}
+.prog-close:hover{color:#000;}
+.tabs{display:flex;margin-bottom:2rem;border-bottom:2px solid #e9ecef;}
+.tab{padding:1rem 2rem;cursor:pointer;border:none;background:none;font-size:1rem;color:#6c757d;border-bottom:2px solid transparent;transition:all 0.3s ease;}
+.tab.active{color:#5cb85c;border-bottom-color:#5cb85c;}
+.tab:hover{color:#5cb85c;}
+.tab-content{display:none;}
+.tab-content.active{display:block;}
+.patient-info{background:#f8f9fa;padding:1.5rem;border-radius:8px;margin-bottom:2rem;}
+.patient-info h4{color:#5cb85c;margin-bottom:1rem;}
+.patient-info input{width:100%;padding:0.5rem;border:1px solid #dee2e6;border-radius:4px;margin-bottom:1rem;}
+.form-group{margin-bottom:1.5rem;padding:1rem;background:#f8f9fa;border-radius:8px;}
+.form-group h4{color:#5cb85c;margin-bottom:1rem;}
+.form-item{margin-bottom:1.5rem;padding:1rem;background:white;border-radius:8px;border-left:4px solid #dee2e6;}
+.form-item.completed{border-left-color:#28a745;}
+.radio-group{display:flex;flex-wrap:wrap;gap:1rem;margin-top:0.5rem;}
+.radio-option{display:flex;align-items:center;cursor:pointer;padding:0.5rem 1rem;border:2px solid #dee2e6;border-radius:25px;transition:all 0.3s ease;min-width:150px;}
+.radio-option:hover{border-color:#5cb85c;background:#f0f7ff;}
+.radio-option.selected{border-color:#28a745;background:#d4edda;color:#155724;}
+.score-display{background:linear-gradient(135deg,#5cb85c,#449d44);color:white;padding:2rem;border-radius:12px;text-align:center;margin:2rem 0;}
+.score-number{font-size:3rem;font-weight:bold;margin-bottom:0.5rem;}
+.score-interpretation{font-size:1.2rem;margin-bottom:1rem;}
+.score-description{font-size:1rem;opacity:0.9;}
+.scale-table{width:100%;border-collapse:collapse;margin:1rem 0;font-size:0.9rem;}
+.scale-table th,.scale-table td{border:1px solid #dee2e6;padding:0.75rem;text-align:left;}
+.scale-table th{background-color:#f8f9fa;font-weight:600;color:#495057;}
+.scale-table tbody tr:nth-child(even){background-color:#f8f9fa;}
+.btn-success{background:#28a745;color:white;}
+.btn-success:hover{background:#218838;}
+.reset-btn{background:#dc3545;color:white;}
+.reset-btn:hover{background:#c82333;}
+.progress-bar{background:#e9ecef;border-radius:10px;height:8px;margin:1rem 0;}
+.progress-fill{background:linear-gradient(90deg,#28a745,#20c997);height:100%;border-radius:10px;transition:width 0.3s ease;}
+@media (max-width:768px){.prognosi-grid{grid-template-columns:1fr;}.prog-modal-content{width:98%;margin:1% auto;padding:1rem;}.tabs{flex-wrap:wrap;}.tab{padding:0.75rem 1rem;font-size:0.9rem;}.radio-group{flex-direction:column;}.radio-option{min-width:auto;}}
+</style>

--- a/gestione-sintomi/strumenti-ramsey.php
+++ b/gestione-sintomi/strumenti-ramsey.php
@@ -1,0 +1,10 @@
+<?php
+// placeholder per Ramsey
+?>
+<section id="ramsey-home" class="p-4" style="display:none;">
+  <div class="bg-white p-4 rounded shadow-sm">
+    <h5 class="mb-3"><i class="fas fa-bed me-2"></i>Ramsey</h5>
+    <p>Sezione in costruzione.</p>
+  </div>
+</section>
+

--- a/gestione-sintomi/strumenti-rass.php
+++ b/gestione-sintomi/strumenti-rass.php
@@ -1,0 +1,10 @@
+<?php
+// placeholder per RASS
+?>
+<section id="rass-home" class="p-4" style="display:none;">
+  <div class="bg-white p-4 rounded shadow-sm">
+    <h5 class="mb-3"><i class="fas fa-bed me-2"></i>RASS</h5>
+    <p>Sezione in costruzione.</p>
+  </div>
+</section>
+

--- a/gestione-sintomi/strumenti-zcb7.php
+++ b/gestione-sintomi/strumenti-zcb7.php
@@ -1,0 +1,10 @@
+<?php
+// placeholder per ZCB 7 punti
+?>
+<section id="zcb7-home" class="p-4" style="display:none;">
+  <div class="bg-white p-4 rounded shadow-sm">
+    <h5 class="mb-3"><i class="fas fa-users me-2"></i>ZCB 7 p.ti</h5>
+    <p>Sezione in costruzione.</p>
+  </div>
+</section>
+


### PR DESCRIPTION
## Summary
- ridenomina il menu come **Strumenti di Valutazione** e introduce tutte le nuove categorie con le relative scale
- aggiunge la pagina `strumenti-prognosi.php` con moduli interattivi per PPI e PaP Score
- crea sezioni segnaposto per ESAS, DN4, 4AT, CAM, RASS, Ramsey, ZCB7 e FAMCARE2

## Testing
- `php -l gestione-sintomi/index.php`
- `php -l gestione-sintomi/strumenti-esas.php`
- `php -l gestione-sintomi/strumenti-dn4.php`
- `php -l gestione-sintomi/strumenti-4at.php`
- `php -l gestione-sintomi/strumenti-cam.php`
- `php -l gestione-sintomi/strumenti-rass.php`
- `php -l gestione-sintomi/strumenti-ramsey.php`
- `php -l gestione-sintomi/strumenti-zcb7.php`
- `php -l gestione-sintomi/strumenti-famcare2.php`
- `php -l gestione-sintomi/strumenti-prognosi.php`


------
https://chatgpt.com/codex/tasks/task_e_6896e1769cc88328881ebefac51edd56