### PR TITLE
Add interactive IDC-PAL glossary

### DIFF
--- a/gestione-sintomi/css/idcpal.css
+++ b/gestione-sintomi/css/idcpal.css
@@ -1,8 +1,8 @@
 :root {
-  --idcpal-primary: #5cb85c;
-  --idcpal-secondary: #449d44;
-  --idcpal-accent: #28a745;
-  --idcpal-light: #d4edda;
+  --idcpal-primary: #007bff;
+  --idcpal-secondary: #0056b3;
+  --idcpal-accent: #004085;
+  --idcpal-light: #d1ecf1;
   --idcpal-border: #e9ecef;
   --idcpal-warning: #ffc107;
   --idcpal-danger: #dc3545;
@@ -71,7 +71,7 @@
   background: var(--idcpal-primary);
   color: white;
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(92, 184, 92, 0.3);
+  box-shadow: 0 4px 12px rgba(0, 123, 255, 0.3);
 }
 
 .content-section {
@@ -127,6 +127,7 @@
   margin-bottom: 1rem;
   transition: all 0.3s ease;
   cursor: pointer;
+  flex-direction: column;
 }
 
 .complexity-item:hover {
@@ -139,9 +140,16 @@
   border-color: var(--idcpal-accent);
 }
 
+.item-main {
+  display: flex;
+  align-items: flex-start;
+  width: 100%;
+}
+
 .item-checkbox {
   margin-right: 1rem;
   transform: scale(1.2);
+  accent-color: var(--idcpal-primary);
 }
 
 .item-content {
@@ -152,12 +160,43 @@
   font-weight: 700;
   color: var(--idcpal-primary);
   margin-bottom: 0.3rem;
+  display: flex;
+  align-items: center;
 }
 
 .item-text {
   color: #2c3e50;
   margin-bottom: 0.5rem;
   line-height: 1.4;
+}
+
+.inline-glossary {
+  width: 100%;
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid #e9ecef;
+  animation: slideDown 0.3s ease;
+}
+
+.inline-glossary-content {
+  background: #f8f9fa;
+  padding: 1rem;
+  border-radius: 8px;
+  border-left: 4px solid var(--idcpal-primary);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: #495057;
+}
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .item-badge {
@@ -169,9 +208,9 @@
 }
 
 .badge-c {
-  background: #fff3cd;
-  color: #856404;
-  border: 1px solid #ffeaa7;
+  background: #d1ecf1;
+  color: #0c5460;
+  border: 1px solid #bee5eb;
 }
 
 .badge-ac {
@@ -234,7 +273,7 @@
 
 .classification-option:hover {
   border-color: var(--idcpal-primary);
-  background: rgba(92, 184, 92, 0.1);
+  background: rgba(0, 123, 255, 0.1);
 }
 
 .classification-option.selected {
@@ -347,7 +386,7 @@
 .btn-primary-custom:hover {
   background: linear-gradient(135deg, var(--idcpal-secondary), var(--idcpal-accent));
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(92, 184, 92, 0.3);
+  box-shadow: 0 4px 12px rgba(0, 123, 255, 0.3);
   color: white;
 }
 
@@ -383,4 +422,3 @@
     font-size: 2rem; 
   }
 }
-

--- a/gestione-sintomi/js/esas.js
+++ b/gestione-sintomi/js/esas.js
@@ -20,10 +20,14 @@ document.addEventListener('DOMContentLoaded', function() {
 
 // Funzione per cambiare modalità
 function switchMode(mode) {
-  document.querySelectorAll('.mode-btn').forEach(btn => btn.classList.remove('active'));
-  document.getElementById(mode + '-btn').classList.add('active');
-  document.querySelectorAll('.content-section').forEach(section => section.classList.remove('active'));
-  document.getElementById(mode + '-section').classList.add('active');
+  const container = document.getElementById('esas-home');
+  if (!container) return;
+  container.querySelectorAll('.mode-btn').forEach(btn => btn.classList.remove('active'));
+  const btn = container.querySelector('#' + mode + '-btn');
+  if (btn) btn.classList.add('active');
+  container.querySelectorAll('.content-section').forEach(section => section.classList.remove('active'));
+  const section = container.querySelector('#' + mode + '-section');
+  if (section) section.classList.add('active');
 }
 
 // Setup event listeners per le scale numeriche

--- a/gestione-sintomi/js/idcpal.js
+++ b/gestione-sintomi/js/idcpal.js
@@ -5,7 +5,7 @@ let selectedItems = new Set();
 // Inizializzazione
 document.addEventListener('DOMContentLoaded', function() {
   const today = new Date().toISOString().split('T')[0];
-  const compilationDate = document.getElementById('compilation-date');
+  const compilationDate = document.getElementById('idcpal-compilation-date');
   if (compilationDate) compilationDate.value = today;
   
   setupIDCPALListeners();
@@ -14,10 +14,14 @@ document.addEventListener('DOMContentLoaded', function() {
 
 // Funzione per cambiare modalità (come switchMode in ESAS)
 function switchIDCPALMode(mode) {
-  document.querySelectorAll('.mode-btn').forEach(btn => btn.classList.remove('active'));
-  document.getElementById(mode + '-btn').classList.add('active');
-  document.querySelectorAll('.content-section').forEach(section => section.classList.remove('active'));
-  document.getElementById(mode + '-section').classList.add('active');
+  const container = document.getElementById('idcpal-home');
+  if (!container) return;
+  container.querySelectorAll('.mode-btn').forEach(btn => btn.classList.remove('active'));
+  const btn = container.querySelector('#idcpal-' + mode + '-btn');
+  if (btn) btn.classList.add('active');
+  container.querySelectorAll('.content-section').forEach(section => section.classList.remove('active'));
+  const section = container.querySelector('#idcpal-' + mode + '-section');
+  if (section) section.classList.add('active');
 }
 
 // Setup event listeners
@@ -54,8 +58,8 @@ function toggleIDCPALItem(code, level) {
 
 // Funzione per aggiornare i conteggi (come updateResults in ESAS)
 function updateIDCPALCounts() {
-  const c = document.getElementById('count-c');
-  const ac = document.getElementById('count-ac');
+  const c = document.getElementById('idcpal-count-c');
+  const ac = document.getElementById('idcpal-count-ac');
   if (c) c.textContent = `${idcpalCounts.C || 0} C`;
   if (ac) ac.textContent = `${idcpalCounts.AC || 0} AC`;
   
@@ -86,8 +90,8 @@ function autoClassifyComplexity() {
 
 // Funzione per salvare la valutazione (come saveESAS)
 function saveIDCPAL() {
-  const patientName = document.getElementById('patient-name')?.value || '';
-  const compilationDate = document.getElementById('compilation-date')?.value || '';
+  const patientName = document.getElementById('idcpal-patient-name')?.value || '';
+  const compilationDate = document.getElementById('idcpal-compilation-date')?.value || '';
   
   if (!patientName) {
     alert('Inserire il nome del paziente');
@@ -99,7 +103,7 @@ function saveIDCPAL() {
     return;
   }
   
-  const finalClassification = document.querySelector('input[name="classification"]:checked')?.value || '';
+  const finalClassification = document.querySelector('input[name="idcpal-classification"]:checked')?.value || '';
   
   const data = {
     paziente: patientName,
@@ -128,12 +132,12 @@ function resetIDCPAL() {
     document.querySelectorAll('.complexity-item').forEach(el => el.classList.remove('selected'));
     updateIDCPALCounts();
     
-    ['patient-name', 'patient-birth', 'compilation-date'].forEach(id => { 
-      const el = document.getElementById(id); 
-      if (el && id !== 'compilation-date') el.value = ''; 
+    ['idcpal-patient-name', 'idcpal-patient-birth', 'idcpal-compilation-date'].forEach(id => {
+      const el = document.getElementById(id);
+      if (el && id !== 'idcpal-compilation-date') el.value = '';
     });
-    
-    document.querySelectorAll('input[name="classification"]').forEach(r => r.checked = false);
+
+    document.querySelectorAll('input[name="idcpal-classification"]').forEach(r => r.checked = false);
     document.querySelectorAll('.classification-option').forEach(o => {
       o.classList.remove('selected');
       o.style.border = '2px solid #e9ecef';
@@ -143,9 +147,9 @@ function resetIDCPAL() {
 
 // Funzione per stampare la valutazione compilata (come printESAS)
 function printIDCPAL() {
-  const patientName = document.getElementById('patient-name')?.value || 'Paziente';
-  const compilationDate = document.getElementById('compilation-date')?.value || new Date().toISOString().split('T')[0];
-  const finalClassification = document.querySelector('input[name="classification"]:checked')?.value || 'Non specificata';
+  const patientName = document.getElementById('idcpal-patient-name')?.value || 'Paziente';
+  const compilationDate = document.getElementById('idcpal-compilation-date')?.value || new Date().toISOString().split('T')[0];
+  const finalClassification = document.querySelector('input[name="idcpal-classification"]:checked')?.value || 'Non specificata';
   
   // Raccolta elementi selezionati con dettagli
   const selectedItemsDetails = [];
@@ -229,7 +233,7 @@ function printIDCPAL() {
 
 // Funzione per stampare il template (come printTemplate in ESAS)
 function printIDCPALTemplate() {
-  const templateContent = document.querySelector('#visualize-section .pdf-template').innerHTML;
+  const templateContent = document.querySelector('#idcpal-visualize-section .pdf-template').innerHTML;
   const printWindow = window.open('', '_blank');
   printWindow.document.write(`
     <html>
@@ -253,10 +257,28 @@ function downloadIDCPALTemplate() {
   alert('Funzionalità di download PDF in sviluppo. Per ora utilizza la stampa per salvare come PDF.');
 }
 
+// Funzioni per il glossario inline
+function toggleGlossaryInline(code) {
+  const glossary = document.getElementById(`glossary-${code}`);
+  if (!glossary) return;
+  
+  document.querySelectorAll('.inline-glossary').forEach(g => {
+    if (g.id !== `glossary-${code}`) {
+      g.style.display = 'none';
+    }
+  });
+  
+  if (glossary.style.display === 'none' || !glossary.style.display) {
+    glossary.style.display = 'block';
+  } else {
+    glossary.style.display = 'none';
+  }
+}
+
 // Funzioni per il glossario
 function filterIDCPALGlossary() {
-  const query = (document.getElementById('glossary-search')?.value || '').toLowerCase();
-  document.querySelectorAll('#glossary-content .glossary-item').forEach(item => {
+  const query = (document.getElementById('idcpal-glossary-search')?.value || '').toLowerCase();
+  document.querySelectorAll('#idcpal-glossary-content .glossary-item').forEach(item => {
     const text = item.textContent.toLowerCase();
     item.style.display = text.includes(query) ? '' : 'none';
   });
@@ -295,4 +317,3 @@ document.addEventListener('keydown', (e) => {
 });
 
 console.log('✅ IDC-PAL JavaScript caricato correttamente');
-

--- a/gestione-sintomi/strumenti-idcpal.php
+++ b/gestione-sintomi/strumenti-idcpal.php
@@ -1,4 +1,108 @@
 <?php
+$idcpal_sections = [
+  '1' => [
+    'icon' => 'fas fa-user',
+    'title' => 'Elementi dipendenti dal paziente',
+    'subsections' => [
+      '1.1' => [
+        'title' => 'Contesto',
+        'items' => [
+          ['code' => '1.1a', 'text' => 'Il paziente è un bambino o un adolescente', 'level' => 'AC', 'description' => "Si considera il periodo di vita dalla nascita al completo sviluppo dell'organismo (infanzia e adolescenza fino a 18 anni). L'assistenza pediatrica presenta complessità specifiche."],
+          ['code' => '1.1b', 'text' => 'Il paziente è un professionista sanitario', 'level' => 'C', 'description' => 'Quando il fatto di essere un professionista della salute aggiunge difficoltà alla situazione o al processo decisionale.'],
+          ['code' => '1.1c', 'text' => 'Barriere linguistiche o culturali', 'level' => 'C', 'description' => 'Difficoltà di comunicazione dovute a differenze linguistiche o culturali che compromettono la comprensione delle cure.'],
+          ['code' => '1.1d', 'text' => 'Problemi socio-economici', 'level' => 'C', 'description' => 'Condizioni economiche precarie che limitano l\'accesso alle cure o l\'acquisto di dispositivi necessari.'],
+          ['code' => '1.1e', 'text' => 'Difficoltà di accesso ai servizi sanitari', 'level' => 'AC', 'description' => 'Ostacoli geografici, logistici o organizzativi che impediscono l\'accesso tempestivo ai servizi sanitari specialistici.'],
+        ],
+      ],
+      '1.2' => [
+        'title' => 'Sintomi',
+        'items' => [
+          ['code' => '1.2a', 'text' => 'Sintomi di difficile controllo', 'level' => 'AC', 'description' => 'Sintomi che non rispondono ai trattamenti standard o richiedono misure eccezionali.'],
+          ['code' => '1.2b', 'text' => 'Sintomi che interferiscono con il sonno', 'level' => 'C', 'description' => 'Disturbi che impediscono un riposo adeguato e generano affaticamento.'],
+          ['code' => '1.2c', 'text' => 'Sintomi che interferiscono con la capacità comunicativa', 'level' => 'C', 'description' => 'Deficit che impediscono al paziente di esprimersi o comprendere.'],
+          ['code' => '1.2d', 'text' => 'Presenza di ulcere cutanee maleodoranti', 'level' => 'C', 'description' => 'Lesioni cutanee con odore sgradevole che provocano disagio.'],
+        ],
+      ],
+      '1.3' => [
+        'title' => 'Aspetti psicologici',
+        'items' => [
+          ['code' => '1.3a', 'text' => 'Presenza di delirium', 'level' => 'AC', 'description' => "Stato confusionale acuto con disturbi dell'attenzione e percezioni alterate."],
+          ['code' => '1.3b', 'text' => 'Presenza di ansia o depressione clinicamente significativa', 'level' => 'C', 'description' => 'Sintomi psicologici che richiedono intervento specialistico.'],
+          ['code' => '1.3c', 'text' => 'Manifestazioni di collera o aggressività', 'level' => 'C', 'description' => 'Reazioni emotive intense dirette verso sé o gli altri.'],
+          ['code' => '1.3d', 'text' => 'Paura o negazione della morte', 'level' => 'AC', 'description' => 'Rifiuto persistente o timore paralizzante del processo di fine vita.'],
+          ['code' => '1.3e', 'text' => 'Richiesta di eutanasia o suicidio assistito', 'level' => 'AC', 'description' => 'Domanda esplicita di anticipare la morte con assistenza medica.'],
+        ],
+      ],
+      '1.4' => [
+        'title' => 'Aspetti spirituali',
+        'items' => [
+          ['code' => '1.4a', 'text' => 'Sofferenza spirituale', 'level' => 'C', 'description' => 'Senso di perdita di significato o disperazione esistenziale.'],
+          ['code' => '1.4b', 'text' => 'Conflitti con le proprie credenze religiose', 'level' => 'C', 'description' => 'Dissonanze tra il percorso di cura e le convinzioni spirituali personali.'],
+        ],
+      ],
+    ],
+  ],
+  '2' => [
+    'icon' => 'fas fa-users',
+    'title' => 'Elementi dipendenti dalla famiglia',
+    'subsections' => [
+      '2.1' => [
+        'title' => 'Contesto familiare',
+        'items' => [
+          ['code' => '2.1a', 'text' => 'Assenza di supporto familiare', 'level' => 'AC', 'description' => 'Il paziente non dispone di una rete familiare di sostegno.'],
+          ['code' => '2.1b', 'text' => 'Famiglia monoparentale o single parent', 'level' => 'C', 'description' => 'Responsabilità assistenziale concentrata su una sola persona.'],
+          ['code' => '2.1c', 'text' => 'Presenza di minori nel nucleo familiare', 'level' => 'C', 'description' => 'Presenza di figli piccoli che necessitano di attenzioni dedicate.'],
+          ['code' => '2.1d', 'text' => 'Caregiver principale con età avanzata o malato', 'level' => 'C', 'description' => 'Il caregiver presenta limitazioni fisiche o patologiche.'],
+        ],
+      ],
+      '2.2' => [
+        'title' => 'Dinamiche familiari',
+        'items' => [
+          ['code' => '2.2a', 'text' => 'Conflitti familiari maggiori', 'level' => 'AC', 'description' => 'Disaccordi significativi che compromettono l\'assistenza.'],
+          ['code' => '2.2b', 'text' => 'Difficoltà nella comunicazione familiare', 'level' => 'C', 'description' => 'Incapacità di condividere informazioni o emozioni in modo efficace.'],
+          ['code' => '2.2c', 'text' => 'Rifiuto di accettazione della prognosi', 'level' => 'AC', 'description' => 'La famiglia non riconosce la gravità della malattia.'],
+          ['code' => '2.2d', 'text' => 'Claudicatio familiare o burnout del caregiver', 'level' => 'C', 'description' => 'Esaurimento fisico o emotivo del caregiver principale.'],
+        ],
+      ],
+      '2.3' => [
+        'title' => 'Aspetti psico-sociali familiari',
+        'items' => [
+          ['code' => '2.3a', 'text' => 'Storia di perdite multiple o traumatiche', 'level' => 'C', 'description' => 'Eventi lutti precedenti che aumentano la vulnerabilità emotiva.'],
+          ['code' => '2.3b', 'text' => 'Problemi di salute mentale in familiari', 'level' => 'C', 'description' => 'Presenza di disturbi psichiatrici che interferiscono con l\'assistenza.'],
+        ],
+      ],
+    ],
+  ],
+  '3' => [
+    'icon' => 'fas fa-hospital',
+    'title' => 'Elementi dipendenti dal sistema sanitario',
+    'subsections' => [
+      '3.1' => [
+        'title' => 'Aspetti organizzativi',
+        'items' => [
+          ['code' => '3.1a', 'text' => 'Necessità di interventi urgenti o emergenze ricorrenti', 'level' => 'AC', 'description' => 'Situazioni cliniche che richiedono risposte rapide e frequenti.'],
+          ['code' => '3.1b', 'text' => 'Necessità di coordinamento tra più servizi', 'level' => 'C', 'description' => 'Coinvolgimento simultaneo di diversi livelli assistenziali.'],
+          ['code' => '3.1c', 'text' => 'Necessità di dispositivi o procedure complesse', 'level' => 'C', 'description' => 'Richiesta di tecnologie avanzate o procedure specialistiche.'],
+          ['code' => '3.1d', 'text' => 'Difficoltà nel reperimento di risorse', 'level' => 'C', 'description' => 'Scarsa disponibilità di mezzi o personale adeguato.'],
+        ],
+      ],
+      '3.2' => [
+        'title' => 'Aspetti professionali',
+        'items' => [
+          ['code' => '3.2a', 'text' => "Conflitti etici nell'équipe di cura", 'level' => 'AC', 'description' => 'Dilemmi etici che generano tensione tra i professionisti.'],
+          ['code' => '3.2b', 'text' => "Disaccordo nell'équipe sul piano di cura", 'level' => 'C', 'description' => 'Mancanza di consenso tra i membri del team terapeutico.'],
+        ],
+      ],
+      '3.3' => [
+        'title' => 'Aspetti legali',
+        'items' => [
+          ['code' => '3.3a', 'text' => 'Questioni medico-legali complesse', 'level' => 'AC', 'description' => 'Aspetti legali che richiedono consulenza specialistica.'],
+          ['code' => '3.3b', 'text' => 'Problemi di consenso informato', 'level' => 'C', 'description' => 'Difficoltà nel ottenere o validare il consenso del paziente.'],
+        ],
+      ],
+    ],
+  ],
+];
 ?>
 <link rel="stylesheet" href="css/idcpal.css">
 <section id="idcpal-home" class="p-4" style="display:none;">
@@ -25,22 +129,22 @@
     </div>
 
     <div class="mode-selector">
-      <a href="#" class="mode-btn active" onclick="switchIDCPALMode('compile')" id="compile-btn">
+      <a href="#" class="mode-btn active" onclick="switchIDCPALMode('compile')" id="idcpal-compile-btn">
         <i class="fas fa-edit"></i>
         Compila IDC-PAL
       </a>
-      <a href="#" class="mode-btn" onclick="switchIDCPALMode('visualize')" id="visualize-btn">
+      <a href="#" class="mode-btn" onclick="switchIDCPALMode('visualize')" id="idcpal-visualize-btn">
         <i class="fas fa-table"></i>
         Visualizza Scala
       </a>
-      <a href="#" class="mode-btn" onclick="switchIDCPALMode('glossary')" id="glossary-btn">
+      <a href="#" class="mode-btn" onclick="switchIDCPALMode('glossary')" id="idcpal-glossary-btn">
         <i class="fas fa-book"></i>
         Glossario
       </a>
     </div>
 
     <!-- SEZIONE COMPILA -->
-    <div id="compile-section" class="content-section active">
+    <div id="idcpal-compile-section" class="content-section active">
       <div class="compile-form">
         <div class="patient-info">
           <h4 class="mb-3">
@@ -50,169 +154,59 @@
           <div class="row g-3">
             <div class="col-md-4">
               <label class="form-label">Nome e Cognome</label>
-              <input type="text" class="form-control" id="patient-name" placeholder="Inserisci nome paziente">
+              <input type="text" class="form-control" id="idcpal-patient-name" placeholder="Inserisci nome paziente">
             </div>
             <div class="col-md-4">
               <label class="form-label">Data di nascita</label>
-              <input type="date" class="form-control" id="patient-birth">
+              <input type="date" class="form-control" id="idcpal-patient-birth">
             </div>
             <div class="col-md-4">
               <label class="form-label">Data compilazione</label>
-              <input type="date" class="form-control" id="compilation-date">
+              <input type="date" class="form-control" id="idcpal-compilation-date">
             </div>
           </div>
         </div>
 
-        <!-- Sezione 1: Paziente -->
+<?php foreach ($idcpal_sections as $num => $section): ?>
         <div class="complexity-section">
           <div class="section-header">
-            <i class="fas fa-user me-2"></i>1. Elementi dipendenti dal paziente
+            <i class="<?= $section['icon']; ?> me-2"></i><?= $num . '. ' . $section['title']; ?>
           </div>
           <div class="section-content">
-            <h6 class="text-muted mb-3">1.1 - Contesto</h6>
-            <div class="complexity-item" data-code="1.1a">
-              <input type="checkbox" class="form-check-input item-checkbox" id="item-1.1a" onchange="toggleIDCPALItem('1.1a', 'AC')">
-              <div class="item-content">
-                <div class="item-code">1.1a</div>
-                <div class="item-text">Il paziente è un bambino o un adolescente</div>
-                <span class="item-badge badge-ac">AC</span>
+<?php $firstSub = true; foreach ($section['subsections'] as $subnum => $sub): ?>
+            <h6 class="text-muted mb-3<?= $firstSub ? '' : ' mt-4'; ?>"><?= $subnum . ' - ' . $sub['title']; ?></h6>
+<?php $firstSub = false; foreach ($sub['items'] as $item): ?>
+            <div class="complexity-item" data-code="<?= $item['code']; ?>" onclick="toggleGlossaryInline('<?= $item['code']; ?>')">
+              <div class="item-main">
+                <input type="checkbox" class="form-check-input item-checkbox" id="item-<?= $item['code']; ?>" onchange="toggleIDCPALItem('<?= $item['code']; ?>', '<?= $item['level']; ?>')" onclick="event.stopPropagation()">
+                <div class="item-content">
+                  <div class="item-code"><?= $item['code']; ?> <i class="fas fa-info-circle text-primary ms-1" title="Clicca per info"></i></div>
+                  <div class="item-text"><?= $item['text']; ?></div>
+                  <span class="item-badge <?= $item['level'] === 'AC' ? 'badge-ac' : 'badge-c'; ?>"><?= $item['level']; ?></span>
+                </div>
+              </div>
+              <div class="inline-glossary" id="glossary-<?= $item['code']; ?>" style="display:none;">
+                <div class="inline-glossary-content">
+                  <strong>Descrizione:</strong> <?= $item['description']; ?>
+                </div>
               </div>
             </div>
-            <div class="complexity-item" data-code="1.1b">
-              <input type="checkbox" class="form-check-input item-checkbox" id="item-1.1b" onchange="toggleIDCPALItem('1.1b', 'C')">
-              <div class="item-content">
-                <div class="item-code">1.1b</div>
-                <div class="item-text">Il paziente è un professionista sanitario</div>
-                <span class="item-badge badge-c">C</span>
-              </div>
-            </div>
-
-            <h6 class="text-muted mb-3 mt-4">1.2 - Sintomi</h6>
-            <div class="complexity-item" data-code="1.2a">
-              <input type="checkbox" class="form-check-input item-checkbox" id="item-1.2a" onchange="toggleIDCPALItem('1.2a', 'AC')">
-              <div class="item-content">
-                <div class="item-code">1.2a</div>
-                <div class="item-text">Sintomi di difficile controllo</div>
-                <span class="item-badge badge-ac">AC</span>
-              </div>
-            </div>
-            <div class="complexity-item" data-code="1.2b">
-              <input type="checkbox" class="form-check-input item-checkbox" id="item-1.2b" onchange="toggleIDCPALItem('1.2b', 'C')">
-              <div class="item-content">
-                <div class="item-code">1.2b</div>
-                <div class="item-text">Sintomi che interferiscono con il sonno</div>
-                <span class="item-badge badge-c">C</span>
-              </div>
-            </div>
-            <div class="complexity-item" data-code="1.2c">
-              <input type="checkbox" class="form-check-input item-checkbox" id="item-1.2c" onchange="toggleIDCPALItem('1.2c', 'C')">
-              <div class="item-content">
-                <div class="item-code">1.2c</div>
-                <div class="item-text">Sintomi che interferiscono con la capacità comunicativa</div>
-                <span class="item-badge badge-c">C</span>
-              </div>
-            </div>
-
-            <h6 class="text-muted mb-3 mt-4">1.3 - Aspetti psicologici</h6>
-            <div class="complexity-item" data-code="1.3a">
-              <input type="checkbox" class="form-check-input item-checkbox" id="item-1.3a" onchange="toggleIDCPALItem('1.3a', 'AC')">
-              <div class="item-content">
-                <div class="item-code">1.3a</div>
-                <div class="item-text">Presenza di delirium</div>
-                <span class="item-badge badge-ac">AC</span>
-              </div>
-            </div>
-            <div class="complexity-item" data-code="1.3b">
-              <input type="checkbox" class="form-check-input item-checkbox" id="item-1.3b" onchange="toggleIDCPALItem('1.3b', 'C')">
-              <div class="item-content">
-                <div class="item-code">1.3b</div>
-                <div class="item-text">Presenza di ansia o depressione clinicamente significativa</div>
-                <span class="item-badge badge-c">C</span>
-              </div>
-            </div>
-            <div class="complexity-item" data-code="1.3c">
-              <input type="checkbox" class="form-check-input item-checkbox" id="item-1.3c" onchange="toggleIDCPALItem('1.3c', 'C')">
-              <div class="item-content">
-                <div class="item-code">1.3c</div>
-                <div class="item-text">Manifestazioni di collera o aggressività</div>
-                <span class="item-badge badge-c">C</span>
-              </div>
-            </div>
+<?php endforeach; endforeach; ?>
           </div>
         </div>
+<?php endforeach; ?>
 
-        <!-- Sezione 2: Famiglia -->
-        <div class="complexity-section">
-          <div class="section-header">
-            <i class="fas fa-users me-2"></i>2. Elementi dipendenti dalla famiglia
-          </div>
-          <div class="section-content">
-            <h6 class="text-muted mb-3">2.1 - Contesto familiare</h6>
-            <div class="complexity-item" data-code="2.1a">
-              <input type="checkbox" class="form-check-input item-checkbox" id="item-2.1a" onchange="toggleIDCPALItem('2.1a', 'AC')">
-              <div class="item-content">
-                <div class="item-code">2.1a</div>
-                <div class="item-text">Assenza di supporto familiare</div>
-                <span class="item-badge badge-ac">AC</span>
-              </div>
-            </div>
-            <div class="complexity-item" data-code="2.1b">
-              <input type="checkbox" class="form-check-input item-checkbox" id="item-2.1b" onchange="toggleIDCPALItem('2.1b', 'C')">
-              <div class="item-content">
-                <div class="item-code">2.1b</div>
-                <div class="item-text">Famiglia monoparentale o single parent</div>
-                <span class="item-badge badge-c">C</span>
-              </div>
-            </div>
-            <div class="complexity-item" data-code="2.1c">
-              <input type="checkbox" class="form-check-input item-checkbox" id="item-2.1c" onchange="toggleIDCPALItem('2.1c', 'C')">
-              <div class="item-content">
-                <div class="item-code">2.1c</div>
-                <div class="item-text">Presenza di minori nel nucleo familiare</div>
-                <span class="item-badge badge-c">C</span>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <!-- Sezione 3: Sistema Sanitario -->
-        <div class="complexity-section">
-          <div class="section-header">
-            <i class="fas fa-hospital me-2"></i>3. Elementi dipendenti dal sistema sanitario
-          </div>
-          <div class="section-content">
-            <h6 class="text-muted mb-3">3.1 - Aspetti organizzativi</h6>
-            <div class="complexity-item" data-code="3.1a">
-              <input type="checkbox" class="form-check-input item-checkbox" id="item-3.1a" onchange="toggleIDCPALItem('3.1a', 'AC')">
-              <div class="item-content">
-                <div class="item-code">3.1a</div>
-                <div class="item-text">Necessità di interventi urgenti o emergenze ricorrenti</div>
-                <span class="item-badge badge-ac">AC</span>
-              </div>
-            </div>
-            <div class="complexity-item" data-code="3.1b">
-              <input type="checkbox" class="form-check-input item-checkbox" id="item-3.1b" onchange="toggleIDCPALItem('3.1b', 'C')">
-              <div class="item-content">
-                <div class="item-code">3.1b</div>
-                <div class="item-text">Necessità di coordinamento tra più servizi</div>
-                <span class="item-badge badge-c">C</span>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <!-- Riepilogo -->
         <div class="complexity-summary">
           <h5 class="text-primary mb-3">
             <i class="fas fa-chart-pie me-2"></i>Riepilogo Valutazione
           </h5>
           <div class="summary-counts">
             <div class="count-item">
-              <span class="count-badge badge-c" id="count-c">0 C</span>
+              <span class="count-badge badge-c" id="idcpal-count-c">0 C</span>
               <span class="text-muted">Elementi di Complessità</span>
             </div>
             <div class="count-item">
-              <span class="count-badge badge-ac" id="count-ac">0 AC</span>
+              <span class="count-badge badge-ac" id="idcpal-count-ac">0 AC</span>
               <span class="text-muted">Elementi di Alta Complessità</span>
             </div>
           </div>
@@ -221,15 +215,15 @@
             <label class="form-label fw-bold">Classificazione Finale</label>
             <div class="classification-options">
               <div class="classification-option" data-value="non-complessa">
-                <input type="radio" name="classification" value="non-complessa" class="me-2">
+                <input type="radio" name="idcpal-classification" value="non-complessa" class="me-2">
                 <span>Non Complessa</span>
               </div>
               <div class="classification-option" data-value="complessa">
-                <input type="radio" name="classification" value="complessa" class="me-2">
+                <input type="radio" name="idcpal-classification" value="complessa" class="me-2">
                 <span>Complessa</span>
               </div>
               <div class="classification-option" data-value="altamente-complessa">
-                <input type="radio" name="classification" value="altamente-complessa" class="me-2">
+                <input type="radio" name="idcpal-classification" value="altamente-complessa" class="me-2">
                 <span>Altamente Complessa</span>
               </div>
             </div>
@@ -255,7 +249,7 @@
     </div>
 
     <!-- SEZIONE VISUALIZZA -->
-    <div id="visualize-section" class="content-section">
+    <div id="idcpal-visualize-section" class="content-section">
       <div class="pdf-template">
         <div class="pdf-header">
           <div class="pdf-title">IDC-PAL</div>
@@ -264,9 +258,11 @@
             Strumento per la valutazione della complessità in cure palliative
           </div>
         </div>
+        
         <div class="mb-4">
           <p><strong>Paziente:</strong> _______________________________________________________________  <strong>Data:</strong> _________________</p>
         </div>
+
         <table class="pdf-table">
           <thead>
             <tr style="background:#28a745;color:white;">
@@ -280,57 +276,51 @@
             </tr>
           </thead>
           <tbody>
-            <tr><td><strong>1.1a</strong></td><td>Il paziente è un bambino o un adolescente</td><td><span class="badge-ac">AC</span></td><td>☐</td></tr>
-            <tr><td><strong>1.1b</strong></td><td>Il paziente è un professionista sanitario</td><td><span class="badge-c">C</span></td><td>☐</td></tr>
-            <tr><td><strong>1.2a</strong></td><td>Sintomi di difficile controllo</td><td><span class="badge-ac">AC</span></td><td>☐</td></tr>
-            <tr><td><strong>1.2b</strong></td><td>Sintomi che interferiscono con il sonno</td><td><span class="badge-c">C</span></td><td>☐</td></tr>
-            <tr><td><strong>1.2c</strong></td><td>Sintomi che interferiscono con la capacità comunicativa</td><td><span class="badge-c">C</span></td><td>☐</td></tr>
-            <tr><td><strong>1.3a</strong></td><td>Presenza di delirium</td><td><span class="badge-ac">AC</span></td><td>☐</td></tr>
-            <tr><td><strong>1.3b</strong></td><td>Presenza di ansia o depressione clinicamente significativa</td><td><span class="badge-c">C</span></td><td>☐</td></tr>
-            <tr><td><strong>1.3c</strong></td><td>Manifestazioni di collera o aggressività</td><td><span class="badge-c">C</span></td><td>☐</td></tr>
-            <tr><td><strong>2.1a</strong></td><td>Assenza di supporto familiare</td><td><span class="badge-ac">AC</span></td><td>☐</td></tr>
-            <tr><td><strong>2.1b</strong></td><td>Famiglia monoparentale o single parent</td><td><span class="badge-c">C</span></td><td>☐</td></tr>
-            <tr><td><strong>2.1c</strong></td><td>Presenza di minori nel nucleo familiare</td><td><span class="badge-c">C</span></td><td>☐</td></tr>
-            <tr><td><strong>3.1a</strong></td><td>Necessità di interventi urgenti o emergenze ricorrenti</td><td><span class="badge-ac">AC</span></td><td>☐</td></tr>
-            <tr><td><strong>3.1b</strong></td><td>Necessità di coordinamento tra più servizi</td><td><span class="badge-c">C</span></td><td>☐</td></tr>
+<?php foreach ($idcpal_sections as $secNum => $section): ?>
+<?php foreach ($section['subsections'] as $sub): ?>
+<?php foreach ($sub['items'] as $item): ?>
+            <tr><td><strong><?= $item['code']; ?></strong></td><td><?= $item['text']; ?></td><td><span class="<?= $item['level'] === 'AC' ? 'badge-ac' : 'badge-c'; ?>"><?= $item['level']; ?></span></td><td>☐</td></tr>
+<?php endforeach; ?>
+<?php endforeach; ?>
+<?php endforeach; ?>
           </tbody>
         </table>
-        <p class="text-muted"><small>* LC: Livello di Complessità (C = Complesso, AC = Alta Complessità)</small></p>
+        <div style="font-size:0.8rem;color:#666;">LC*: Livello di Complessità (C = Complessità, AC = Alta Complessità)</div>
       </div>
       <div class="action-buttons">
-        <button type="button" class="btn-custom btn-outline-custom" onclick="printIDCPALTemplate()">
-          <i class="fas fa-print me-2"></i>Stampa Template
+        <button type="button" class="btn-custom btn-primary-custom" onclick="printIDCPALTemplate()">
+          <i class="fas fa-print me-2"></i>
+          Stampa Template
         </button>
         <button type="button" class="btn-custom btn-outline-custom" onclick="downloadIDCPALTemplate()">
-          <i class="fas fa-download me-2"></i>Scarica PDF
+          <i class="fas fa-download me-2"></i>
+          Scarica PDF
         </button>
       </div>
     </div>
 
     <!-- SEZIONE GLOSSARIO -->
-    <div id="glossary-section" class="content-section">
-      <div class="mb-3">
-        <input type="text" id="glossary-search" class="form-control" placeholder="Cerca nel glossario..." onkeyup="filterIDCPALGlossary()">
+    <div id="idcpal-glossary-section" class="content-section">
+      <div class="mb-4">
+        <input type="text" id="idcpal-glossary-search" class="form-control" oninput="filterIDCPALGlossary()" placeholder="Cerca nel glossario...">
       </div>
-      <div id="glossary-content">
+      <div id="idcpal-glossary-content">
+<?php foreach ($idcpal_sections as $section): ?>
+<?php foreach ($section['subsections'] as $sub): ?>
+<?php foreach ($sub['items'] as $item): ?>
         <div class="glossary-item">
           <div class="glossary-header" onclick="toggleIDCPALGlossary(this)">
-            <span class="glossary-code">1.1a</span>
+            <span class="glossary-code"><?= $item['code']; ?></span>
             <i class="fas fa-chevron-right"></i>
           </div>
           <div class="glossary-content">
-            Il paziente è un bambino o un adolescente.
+            <p><strong><?= $item['text']; ?></strong></p>
+            <p><?= $item['description']; ?></p>
           </div>
         </div>
-        <div class="glossary-item">
-          <div class="glossary-header" onclick="toggleIDCPALGlossary(this)">
-            <span class="glossary-code">1.2a</span>
-            <i class="fas fa-chevron-right"></i>
-          </div>
-          <div class="glossary-content">
-            Sintomi di difficile controllo.
-          </div>
-        </div>
+<?php endforeach; ?>
+<?php endforeach; ?>
+<?php endforeach; ?>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- prefix IDC-PAL buttons, sections and form inputs to avoid clashing with other assessment tools
- scope IDC-PAL and ESAS mode toggling to their respective sections
- adjust glossary and summary hooks for the new IDCPAL identifiers

## Testing
- `php -l gestione-sintomi/strumenti-idcpal.php`


------
https://chatgpt.com/codex/tasks/task_e_68976b0ee0f4832892de52888b74a5f1