### PR TITLE
Aggiungi strumenti di prognosi PPI e PaP

### DIFF
--- a/gestione-sintomi/css/prognosi.css
+++ b/gestione-sintomi/css/prognosi.css
@@ -85,29 +85,30 @@
   margin-top: 2rem;
 }
 
-/* Tool cards */
-.tool-card {
+/* Prognosi cards */
+.prognosi-card {
   background: white;
   border-radius: 16px;
   box-shadow: var(--shadow);
   padding: 2rem;
   transition: all 0.3s ease;
   border: 1px solid var(--border-color);
+  cursor: pointer;
 }
 
-.tool-card:hover {
+.prognosi-card:hover {
   transform: translateY(-5px);
   box-shadow: var(--shadow-hover);
   border-color: var(--prognosi-primary);
 }
 
-.tool-header {
+.prognosi-card .card-header {
   display: flex;
   align-items: center;
   margin-bottom: 1.5rem;
 }
 
-.tool-icon-large {
+.prognosi-card .card-icon {
   width: 60px;
   height: 60px;
   border-radius: 12px;
@@ -116,71 +117,61 @@
   justify-content: center;
   margin-right: 1rem;
   font-weight: bold;
-}
-
-.ppi-icon {
-  background: linear-gradient(135deg, #e74c3c, #c0392b);
   color: white;
 }
 
-.pap-icon {
-  background: linear-gradient(135deg, #9b59b6, #8e44ad);
-  color: white;
-}
+.prognosi-card.ppi .card-icon { background: linear-gradient(135deg, #e74c3c, #c0392b); }
+.prognosi-card.pap .card-icon { background: linear-gradient(135deg, #9b59b6, #8e44ad); }
 
-.tool-letters {
-  font-size: 1.5rem;
-  font-weight: 700;
-}
-
-.tool-info h4 {
+.prognosi-card .card-title {
   color: var(--prognosi-primary);
   font-size: 1.4rem;
   font-weight: 600;
   margin-bottom: 0.3rem;
 }
 
-.tool-subtitle {
+.prognosi-card .card-subtitle {
   font-size: 0.9rem;
   color: #6c757d;
   font-weight: 500;
 }
 
-.tool-description {
+.prognosi-card .card-description {
   color: #555;
   margin-bottom: 1.5rem;
   font-size: 0.95rem;
   line-height: 1.6;
 }
 
-.tool-features {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-bottom: 1.5rem;
+.prognosi-card .card-features {
+  list-style: none;
+  margin: 0 0 1.5rem 0;
+  padding: 0;
 }
 
-.feature-badge {
-  background: var(--prognosi-light);
-  color: var(--prognosi-dark);
-  padding: 0.3rem 0.8rem;
-  border-radius: 20px;
-  font-size: 0.8rem;
-  font-weight: 500;
-}
-
-.tool-actions {
-  display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-}
-
-.btn-action {
-  flex: 1;
-  min-width: 120px;
-  padding: 0.75rem 1rem;
-  border-radius: 8px;
+.prognosi-card .card-features li {
+  padding: 0.3rem 0;
   font-size: 0.9rem;
+  color: #666;
+  position: relative;
+  padding-left: 1.2rem;
+}
+
+.prognosi-card .card-features li::before {
+  content: '\25CF';
+  position: absolute;
+  left: 0;
+  color: var(--prognosi-primary);
+  font-size: 0.6rem;
+  top: 0.6rem;
+}
+
+.prognosi-card .card-footer {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border-color);
+  font-size: 0.85rem;
+  color: #6c757d;
 }
 
 /* Patient info card */

--- a/gestione-sintomi/css/prognosi.css
+++ b/gestione-sintomi/css/prognosi.css
@@ -88,12 +88,13 @@
 /* Tool cards */
 .tool-card {
   background: white;
-  border-radius: 20px;
-  border: 3px solid;
-  padding: 2.5rem;
-  box-shadow: var(--shadow);
+  border-radius: 16px;
+  border: 2px solid var(--border-color);
+  padding: 2rem;
+  box-shadow: 0 6px 24px rgba(0,0,0,0.08);
   transition: all 0.3s ease;
   position: relative;
+  overflow: hidden;
 }
 
 .tool-card.ppi {
@@ -104,15 +105,25 @@
   border-color: #9b59b6;
 }
 
+.tool-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: linear-gradient(90deg, var(--prognosi-primary), var(--prognosi-dark));
+}
+
 .tool-card:hover {
-  transform: translateY(-5px);
-  box-shadow: var(--shadow-hover);
+  transform: translateY(-8px);
+  box-shadow: 0 12px 36px rgba(0,0,0,0.15);
 }
 
 .tool-header {
   display: flex;
   align-items: center;
-  margin-bottom: 2rem;
+  margin-bottom: 1.5rem;
 }
 
 .tool-icon-large {

--- a/gestione-sintomi/css/prognosi.css
+++ b/gestione-sintomi/css/prognosi.css
@@ -1,0 +1,560 @@
+:root {
+  --prognosi-primary: #fd7e14;
+  --prognosi-secondary: #e83e8c;
+  --prognosi-accent: #ffc107;
+  --prognosi-light: #fff3e0;
+  --prognosi-dark: #d15502;
+  --border-color: #e9ecef;
+  --shadow: 0 4px 20px rgba(0,0,0,0.08);
+  --shadow-hover: 0 8px 30px rgba(0,0,0,0.15);
+}
+
+/* Contenitori principali */
+.prognosi-container,
+.ppi-container,
+.pap-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+.prognosi-header,
+.ppi-header,
+.pap-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.prognosi-header h1,
+.ppi-header h1,
+.pap-header h1 {
+  color: var(--prognosi-primary);
+  font-size: 2.5rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+
+/* Mode selector */
+.mode-selector {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.mode-btn {
+  padding: 1rem 2rem;
+  background: white;
+  border: 2px solid var(--border-color);
+  border-radius: 12px;
+  text-decoration: none;
+  color: #6c757d;
+  font-weight: 500;
+  transition: all 0.3s ease;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.mode-btn:hover {
+  border-color: var(--prognosi-primary);
+  color: var(--prognosi-primary);
+  text-decoration: none;
+}
+
+.mode-btn.active {
+  background: var(--prognosi-primary);
+  border-color: var(--prognosi-primary);
+  color: white;
+}
+
+/* Content sections */
+.content-section {
+  display: none;
+}
+
+.content-section.active {
+  display: block;
+}
+
+/* Grid per strumenti */
+.prognosi-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+  gap: 2rem;
+  margin-top: 2rem;
+}
+
+/* Tool cards */
+.tool-card {
+  background: white;
+  border-radius: 16px;
+  box-shadow: var(--shadow);
+  padding: 2rem;
+  transition: all 0.3s ease;
+  border: 1px solid var(--border-color);
+}
+
+.tool-card:hover {
+  transform: translateY(-5px);
+  box-shadow: var(--shadow-hover);
+  border-color: var(--prognosi-primary);
+}
+
+.tool-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.tool-icon-large {
+  width: 60px;
+  height: 60px;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 1rem;
+  font-weight: bold;
+}
+
+.ppi-icon {
+  background: linear-gradient(135deg, #e74c3c, #c0392b);
+  color: white;
+}
+
+.pap-icon {
+  background: linear-gradient(135deg, #9b59b6, #8e44ad);
+  color: white;
+}
+
+.tool-letters {
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.tool-info h4 {
+  color: var(--prognosi-primary);
+  font-size: 1.4rem;
+  font-weight: 600;
+  margin-bottom: 0.3rem;
+}
+
+.tool-subtitle {
+  font-size: 0.9rem;
+  color: #6c757d;
+  font-weight: 500;
+}
+
+.tool-description {
+  color: #555;
+  margin-bottom: 1.5rem;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.tool-features {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.feature-badge {
+  background: var(--prognosi-light);
+  color: var(--prognosi-dark);
+  padding: 0.3rem 0.8rem;
+  border-radius: 20px;
+  font-size: 0.8rem;
+  font-weight: 500;
+}
+
+.tool-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.btn-action {
+  flex: 1;
+  min-width: 120px;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
+}
+
+/* Patient info card */
+.patient-info-card {
+  background: #f8f9fa;
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 2rem;
+  border-left: 4px solid var(--prognosi-primary);
+}
+
+.patient-info-card h4 {
+  color: var(--prognosi-primary);
+  margin-bottom: 1rem;
+  font-weight: 600;
+}
+
+/* Form card */
+.form-card {
+  background: white;
+  border-radius: 12px;
+  padding: 2rem;
+  margin-bottom: 2rem;
+  box-shadow: var(--shadow);
+  border: 1px solid var(--border-color);
+}
+
+.form-card h4 {
+  color: var(--prognosi-primary);
+  margin-bottom: 1.5rem;
+  font-weight: 600;
+}
+
+/* Progress indicator */
+.progress-indicator {
+  margin-bottom: 2rem;
+}
+
+.progress-bar {
+  background: #e9ecef;
+  border-radius: 10px;
+  height: 8px;
+  margin-bottom: 0.5rem;
+}
+
+.progress-fill {
+  background: linear-gradient(90deg, var(--prognosi-primary), var(--prognosi-secondary));
+  height: 100%;
+  border-radius: 10px;
+  transition: width 0.3s ease;
+}
+
+/* Form items */
+.form-item {
+  background: #f8f9fa;
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  border-left: 4px solid var(--border-color);
+  transition: all 0.3s ease;
+}
+
+.form-item.completed {
+  border-left-color: #28a745;
+  background: #f0f9ff;
+}
+
+.form-label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  color: #495057;
+  font-size: 1rem;
+}
+
+/* Radio groups */
+.radio-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.radio-option {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  padding: 0.8rem 1.2rem;
+  border: 2px solid var(--border-color);
+  border-radius: 25px;
+  transition: all 0.3s ease;
+  background: white;
+  min-width: 180px;
+  justify-content: center;
+  text-align: center;
+}
+
+.radio-option:hover {
+  border-color: var(--prognosi-primary);
+  background: var(--prognosi-light);
+  transform: translateY(-2px);
+}
+
+.radio-option.selected {
+  border-color: #28a745;
+  background: #d4edda;
+  color: #155724;
+  font-weight: 600;
+}
+
+/* Score display */
+.score-display {
+  background: linear-gradient(135deg, var(--prognosi-primary), var(--prognosi-secondary));
+  border-radius: 16px;
+  padding: 2rem;
+  margin: 2rem 0;
+  color: white;
+  text-align: center;
+  box-shadow: var(--shadow);
+}
+
+.score-header h3 {
+  margin-bottom: 1rem;
+  font-weight: 600;
+}
+
+.score-number {
+  font-size: 3rem;
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+}
+
+.score-interpretation {
+  font-size: 1.2rem;
+  margin-bottom: 1rem;
+  font-weight: 500;
+}
+
+.score-description {
+  font-size: 1rem;
+  opacity: 0.9;
+}
+
+/* Action buttons */
+.action-buttons {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-top: 2rem;
+}
+
+.action-buttons .btn {
+  padding: 0.75rem 2rem;
+  border-radius: 8px;
+  font-weight: 500;
+  transition: all 0.3s ease;
+}
+
+.action-buttons .btn:hover {
+  transform: translateY(-2px);
+}
+
+/* Scale reference */
+.scale-reference {
+  background: white;
+  border-radius: 12px;
+  padding: 2rem;
+  box-shadow: var(--shadow);
+}
+
+.scale-reference h4 {
+  color: var(--prognosi-primary);
+  margin-bottom: 2rem;
+  font-weight: 600;
+}
+
+/* Scale table */
+.scale-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1rem 0;
+  font-size: 0.9rem;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+}
+
+.scale-table th,
+.scale-table td {
+  border: 1px solid var(--border-color);
+  padding: 1rem;
+  text-align: left;
+}
+
+.scale-table th {
+  background: var(--prognosi-primary);
+  color: white;
+  font-weight: 600;
+}
+
+.scale-table tbody tr:nth-child(even) {
+  background: #f8f9fa;
+}
+
+.scale-table tbody tr:hover {
+  background: var(--prognosi-light);
+}
+
+/* Interpretation box */
+.interpretation-box {
+  background: var(--prognosi-light);
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-top: 2rem;
+  border-left: 4px solid var(--prognosi-primary);
+}
+
+.interpretation-box h5 {
+  color: var(--prognosi-dark);
+  margin-bottom: 1rem;
+  font-weight: 600;
+}
+
+.interpretation-box ul {
+  margin: 0;
+  padding-left: 1.5rem;
+  color: #666;
+}
+
+.interpretation-box li {
+  margin-bottom: 0.5rem;
+  line-height: 1.5;
+}
+
+/* Reference section */
+.reference-content {
+  background: white;
+  border-radius: 12px;
+  padding: 2rem;
+  box-shadow: var(--shadow);
+}
+
+.reference-content h3 {
+  color: var(--prognosi-primary);
+  margin-bottom: 2rem;
+  font-weight: 600;
+}
+
+.reference-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.reference-card {
+  background: #f8f9fa;
+  border-radius: 8px;
+  padding: 1.5rem;
+  border-left: 4px solid var(--prognosi-secondary);
+}
+
+.reference-card h5 {
+  color: var(--prognosi-dark);
+  margin-bottom: 1rem;
+  font-weight: 600;
+}
+
+.reference-card p {
+  color: #666;
+  margin: 0;
+  line-height: 1.5;
+}
+
+/* Clinical criteria */
+.clinical-criteria h4 {
+  color: var(--prognosi-primary);
+  margin-bottom: 1.5rem;
+  font-weight: 600;
+}
+
+.criteria-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.criteria-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  background: #f8f9fa;
+  padding: 1rem;
+  border-radius: 8px;
+}
+
+.criteria-item i {
+  margin-top: 0.2rem;
+  font-size: 1.2rem;
+}
+
+.criteria-item strong {
+  color: var(--prognosi-dark);
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.criteria-item p {
+  margin: 0;
+  color: #666;
+}
+
+/* Responsive design */
+@media (max-width: 768px) {
+  .prognosi-container,
+  .ppi-container,
+  .pap-container {
+    padding: 1rem;
+  }
+  
+  .prognosi-grid {
+    grid-template-columns: 1fr;
+  }
+  
+  .mode-selector {
+    flex-direction: column;
+    align-items: center;
+  }
+  
+  .mode-btn {
+    width: 100%;
+    max-width: 300px;
+    justify-content: center;
+  }
+  
+  .tool-header {
+    flex-direction: column;
+    text-align: center;
+  }
+  
+  .tool-icon-large {
+    margin-right: 0;
+    margin-bottom: 1rem;
+  }
+  
+  .tool-actions {
+    flex-direction: column;
+  }
+  
+  .radio-group {
+    flex-direction: column;
+  }
+  
+  .radio-option {
+    min-width: auto;
+    width: 100%;
+  }
+  
+  .action-buttons {
+    flex-direction: column;
+    align-items: center;
+  }
+  
+  .action-buttons .btn {
+    width: 100%;
+    max-width: 250px;
+  }
+  
+  .reference-grid {
+    grid-template-columns: 1fr;
+  }
+  
+  .criteria-item {
+    flex-direction: column;
+    text-align: center;
+  }
+}
+

--- a/gestione-sintomi/css/prognosi.css
+++ b/gestione-sintomi/css/prognosi.css
@@ -5,8 +5,8 @@
   --prognosi-light: #fff3e0;
   --prognosi-dark: #d15502;
   --border-color: #e9ecef;
-  --shadow: 0 4px 20px rgba(0,0,0,0.08);
-  --shadow-hover: 0 8px 30px rgba(0,0,0,0.15);
+  --shadow: 0 8px 32px rgba(0,0,0,0.1);
+  --shadow-hover: 0 12px 40px rgba(0,0,0,0.15);
 }
 
 /* Contenitori principali */
@@ -85,93 +85,156 @@
   margin-top: 2rem;
 }
 
-/* Prognosi cards */
-.prognosi-card {
+/* Tool cards */
+.tool-card {
   background: white;
-  border-radius: 16px;
+  border-radius: 20px;
+  border: 3px solid;
+  padding: 2.5rem;
   box-shadow: var(--shadow);
-  padding: 2rem;
   transition: all 0.3s ease;
-  border: 1px solid var(--border-color);
-  cursor: pointer;
+  position: relative;
 }
 
-.prognosi-card:hover {
+.tool-card.ppi {
+  border-color: #e74c3c;
+}
+
+.tool-card.pap {
+  border-color: #9b59b6;
+}
+
+.tool-card:hover {
   transform: translateY(-5px);
   box-shadow: var(--shadow-hover);
-  border-color: var(--prognosi-primary);
 }
 
-.prognosi-card .card-header {
+.tool-header {
   display: flex;
   align-items: center;
-  margin-bottom: 1.5rem;
+  margin-bottom: 2rem;
 }
 
-.prognosi-card .card-icon {
-  width: 60px;
-  height: 60px;
-  border-radius: 12px;
+.tool-icon-large {
+  width: 80px;
+  height: 80px;
+  border-radius: 16px;
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-right: 1rem;
-  font-weight: bold;
+  margin-right: 1.5rem;
   color: white;
+  font-size: 2rem;
+  font-weight: 700;
+  text-shadow: 0 2px 8px rgba(0,0,0,0.3);
 }
 
-.prognosi-card.ppi .card-icon { background: linear-gradient(135deg, #e74c3c, #c0392b); }
-.prognosi-card.pap .card-icon { background: linear-gradient(135deg, #9b59b6, #8e44ad); }
-
-.prognosi-card .card-title {
-  color: var(--prognosi-primary);
-  font-size: 1.4rem;
-  font-weight: 600;
-  margin-bottom: 0.3rem;
+.ppi-icon {
+  background: linear-gradient(135deg, #e74c3c, #c0392b);
 }
 
-.prognosi-card .card-subtitle {
-  font-size: 0.9rem;
-  color: #6c757d;
+.pap-icon {
+  background: linear-gradient(135deg, #9b59b6, #8e44ad);
+}
+
+.tool-info h4 {
+  font-size: 2.2rem;
+  font-weight: 700;
+  color: #2c3e50;
+  margin-bottom: 0.5rem;
+}
+
+.tool-subtitle {
+  font-size: 1.1rem;
+  color: #7f8c8d;
   font-weight: 500;
+  letter-spacing: 0.5px;
 }
 
-.prognosi-card .card-description {
-  color: #555;
-  margin-bottom: 1.5rem;
-  font-size: 0.95rem;
+.tool-description {
+  font-size: 1.1rem;
   line-height: 1.6;
+  color: #34495e;
+  margin-bottom: 2rem;
 }
 
-.prognosi-card .card-features {
-  list-style: none;
-  margin: 0 0 1.5rem 0;
+.tool-features {
+  background: rgba(46, 204, 113, 0.1);
+  border-radius: 12px;
+  padding: 1rem 1.5rem;
+  margin-bottom: 2rem;
+  border: 1px solid rgba(46, 204, 113, 0.2);
+  display: block;
+}
+
+.feature-badge {
+  color: #27ae60;
+  font-weight: 600;
+  font-size: 1rem;
+  background: none;
+  border: none;
   padding: 0;
+  border-radius: 0;
 }
 
-.prognosi-card .card-features li {
-  padding: 0.3rem 0;
-  font-size: 0.9rem;
-  color: #666;
-  position: relative;
-  padding-left: 1.2rem;
+.tool-actions {
+  display: flex;
+  gap: 1rem;
 }
 
-.prognosi-card .card-features li::before {
-  content: '\25CF';
-  position: absolute;
-  left: 0;
-  color: var(--prognosi-primary);
-  font-size: 0.6rem;
-  top: 0.6rem;
+.btn-action {
+  flex: 1;
+  padding: 1.2rem 2rem;
+  border-radius: 12px;
+  font-weight: 600;
+  font-size: 1.1rem;
+  transition: all 0.3s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.8rem;
+  border: none;
+  cursor: pointer;
 }
 
-.prognosi-card .card-footer {
-  margin-top: 1rem;
-  padding-top: 1rem;
-  border-top: 1px solid var(--border-color);
-  font-size: 0.85rem;
-  color: #6c757d;
+.btn-primary {
+  color: white;
+  box-shadow: 0 4px 15px rgba(0,0,0,0.2);
+}
+
+.ppi-icon ~ * .btn-primary,
+.tool-card:has(.ppi-icon) .btn-primary {
+  background: linear-gradient(135deg, #e74c3c, #c0392b);
+}
+
+.pap-icon ~ * .btn-primary,
+.tool-card:has(.pap-icon) .btn-primary {
+  background: linear-gradient(135deg, #9b59b6, #8e44ad);
+}
+
+.btn-primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 25px rgba(0,0,0,0.25);
+}
+
+.btn-outline-primary {
+  background: white;
+  border: 2px solid;
+}
+
+.tool-card.ppi .btn-outline-primary {
+  border-color: #e74c3c;
+  color: #e74c3c;
+}
+
+.tool-card.pap .btn-outline-primary {
+  border-color: #9b59b6;
+  color: #9b59b6;
+}
+
+.btn-outline-primary:hover {
+  background-color: rgba(0,0,0,0.05);
+  transform: translateY(-2px);
 }
 
 /* Patient info card */

--- a/gestione-sintomi/index.php
+++ b/gestione-sintomi/index.php
@@ -302,7 +302,7 @@
           </div>
 
           <!-- PROGNOSI -->
-          <div class="category-card prognosi" onclick="openCategoryView('prognosi')">
+          <div class="category-card prognosi" onclick="openPrognosiHome()">
             <div class="category-header">
               <div class="category-icon">📈</div>
               <div class="category-info">
@@ -310,7 +310,7 @@
                 <small>2 strumenti</small>
               </div>
               <div class="category-status">
-                <span class="badge bg-warning">In Sviluppo</span>
+                <span class="badge bg-success">✅ Disponibile</span>
               </div>
             </div>
             <div class="category-description">

--- a/gestione-sintomi/index.php
+++ b/gestione-sintomi/index.php
@@ -56,12 +56,28 @@
           <i class="fas fa-syringe me-2"></i>Calcola Dose Rescue
         </a>
       </li>
-
-      <li class="nav-item mb-2">
       <li class="nav-item mb-2">
         <a href="#" class="nav-link" data-target="strumenti-valutazione-home">
           <i class="fas fa-chart-line me-2"></i>Strumenti Valutazione
         </a>
+      </li>
+
+      <li class="nav-item mb-2">
+        <a class="nav-link submenu-toggle collapsed" data-bs-toggle="collapse" data-bs-target="#submenu-prog" href="#" role="button" aria-expanded="false">
+          <i class="fas fa-hourglass-half me-2"></i>Prognosi
+          <i class="fas fa-chevron-right rotate-icon ms-auto"></i>
+        </a>
+        <ul class="nav flex-column collapse" id="submenu-prog" data-bs-parent="#clinical-menu">
+          <li class="nav-item">
+            <a href="#" class="nav-link ms-3" data-target="prognosi-home">Strumenti</a>
+          </li>
+          <li class="nav-item">
+            <a href="#" class="nav-link ms-3" data-target="ppi-home">PPI</a>
+          </li>
+          <li class="nav-item">
+            <a href="#" class="nav-link ms-3" data-target="pap-home">PaP Score</a>
+          </li>
+        </ul>
       </li>
 
       <li class="nav-item">

--- a/gestione-sintomi/index.php
+++ b/gestione-sintomi/index.php
@@ -62,23 +62,6 @@
         </a>
       </li>
 
-      <li class="nav-item mb-2">
-        <a class="nav-link submenu-toggle collapsed" data-bs-toggle="collapse" data-bs-target="#submenu-prog" href="#" role="button" aria-expanded="false">
-          <i class="fas fa-hourglass-half me-2"></i>Prognosi
-          <i class="fas fa-chevron-right rotate-icon ms-auto"></i>
-        </a>
-        <ul class="nav flex-column collapse" id="submenu-prog" data-bs-parent="#clinical-menu">
-          <li class="nav-item">
-            <a href="#" class="nav-link ms-3" data-target="prognosi-home">Strumenti</a>
-          </li>
-          <li class="nav-item">
-            <a href="#" class="nav-link ms-3" data-target="ppi-home">PPI</a>
-          </li>
-          <li class="nav-item">
-            <a href="#" class="nav-link ms-3" data-target="pap-home">PaP Score</a>
-          </li>
-        </ul>
-      </li>
 
       <li class="nav-item">
         <a href="#" class="nav-link" data-bs-toggle="modal" data-bs-target="#medico-modal-home">

--- a/gestione-sintomi/js/app.js
+++ b/gestione-sintomi/js/app.js
@@ -21,7 +21,7 @@ document.addEventListener("DOMContentLoaded", function() {
       const sections = [
         'dashboard-home','gestione-home','sedazione-home',
         'identificazione-home','necpal4-home','spict-home',
-        'idcpal-home','performance-home','prognosi-home','ipos-home','strumenti-valutazione-home',
+        'idcpal-home','performance-home','prognosi-home','ppi-home','pap-home','ipos-home','strumenti-valutazione-home',
         'equianalgesia-section','rescue-section'
       ];
       sections.forEach(id => {

--- a/gestione-sintomi/js/prognosi.js
+++ b/gestione-sintomi/js/prognosi.js
@@ -1,0 +1,704 @@
+// Variabili globali per i punteggi
+let ppiData = {
+  pps: null,
+  oral: null,
+  edema: null,
+  dyspnea: null,
+  delirium: null
+};
+
+let papData = {
+  dyspnea: null,
+  anorexia: null,
+  karnofsky: null,
+  wbc: null,
+  lymphocytes: null,
+  prediction: null
+};
+
+// Inizializzazione
+document.addEventListener('DOMContentLoaded', function() {
+  const today = new Date().toISOString().split('T')[0];
+  const ppiDate = document.getElementById('ppi-date');
+  const papDate = document.getElementById('pap-date');
+  
+  if (ppiDate) ppiDate.value = today;
+  if (papDate) papDate.value = today;
+});
+
+// Funzioni per navigazione principale
+function switchPrognosiMode(mode) {
+  // Rimuove active da tutti i bottoni
+  document.querySelectorAll('#prognosi-home .mode-btn').forEach(btn => {
+    btn.classList.remove('active');
+  });
+  
+  // Nasconde tutte le sezioni
+  document.querySelectorAll('#prognosi-home .content-section').forEach(section => {
+    section.classList.remove('active');
+  });
+  
+  // Attiva il bottone selezionato
+  event.target.classList.add('active');
+  
+  // Mostra la sezione corrispondente
+  document.getElementById(`${mode}-section`).classList.add('active');
+}
+
+// Funzioni per aprire strumenti specifici
+function openPPICompile() {
+  navigateToSection('ppi-home');
+  switchPPIMode('compile');
+}
+
+function openPPIVisualize() {
+  navigateToSection('ppi-home');
+  switchPPIMode('visualize');
+}
+
+function openPAPCompile() {
+  navigateToSection('pap-home');
+  switchPAPMode('compile');
+}
+
+function openPAPVisualize() {
+  navigateToSection('pap-home');
+  switchPAPMode('visualize');
+}
+
+// Funzioni per navigazione PPI
+function switchPPIMode(mode) {
+  // Rimuove active da tutti i bottoni
+  document.querySelectorAll('#ppi-home .mode-btn').forEach(btn => {
+    btn.classList.remove('active');
+  });
+  
+  // Nasconde tutte le sezioni
+  document.querySelectorAll('#ppi-home .content-section').forEach(section => {
+    section.classList.remove('active');
+  });
+  
+  // Attiva il bottone selezionato
+  event.target.classList.add('active');
+  
+  // Mostra la sezione corrispondente
+  document.getElementById(`${mode}-section`).classList.add('active');
+}
+
+// Funzioni per navigazione PaP
+function switchPAPMode(mode) {
+  // Rimuove active da tutti i bottoni
+  document.querySelectorAll('#pap-home .mode-btn').forEach(btn => {
+    btn.classList.remove('active');
+  });
+  
+  // Nasconde tutte le sezioni
+  document.querySelectorAll('#pap-home .content-section').forEach(section => {
+    section.classList.remove('active');
+  });
+  
+  // Attiva il bottone selezionato
+  event.target.classList.add('active');
+  
+  // Mostra la sezione corrispondente
+  document.getElementById(`${mode}-section`).classList.add('active');
+}
+
+// Funzione per selezionare opzioni PPI
+function selectPPI(parameter, value) {
+  // Rimuove la selezione precedente nel gruppo
+  const currentItem = document.getElementById(`ppi-${parameter}-item`);
+  const radioGroup = currentItem.querySelector('.radio-group');
+  
+  radioGroup.querySelectorAll('.radio-option').forEach(option => {
+    option.classList.remove('selected');
+  });
+  
+  // Seleziona l'opzione corrente
+  event.target.closest('.radio-option').classList.add('selected');
+  
+  // Salva il valore
+  ppiData[parameter] = parseFloat(value);
+  
+  // Marca il form item come completato
+  currentItem.classList.add('completed');
+  
+  // Aggiorna il progresso e calcola il punteggio
+  updatePPIProgress();
+  calculatePPI();
+}
+
+// Funzione per selezionare opzioni PaP
+function selectPAP(parameter, value) {
+  // Rimuove la selezione precedente nel gruppo
+  const currentItem = document.getElementById(`pap-${parameter}-item`);
+  const radioGroup = currentItem.querySelector('.radio-group');
+  
+  radioGroup.querySelectorAll('.radio-option').forEach(option => {
+    option.classList.remove('selected');
+  });
+  
+  // Seleziona l'opzione corrente
+  event.target.closest('.radio-option').classList.add('selected');
+  
+  // Salva il valore
+  papData[parameter] = parseFloat(value);
+  
+  // Marca il form item come completato
+  currentItem.classList.add('completed');
+  
+  // Aggiorna il progresso e calcola il punteggio
+  updatePAPProgress();
+  calculatePAP();
+}
+
+// Aggiorna il progresso PPI
+function updatePPIProgress() {
+  const completed = Object.values(ppiData).filter(val => val !== null).length;
+  const total = Object.keys(ppiData).length;
+  const percentage = (completed / total) * 100;
+  
+  const progressBar = document.getElementById('ppi-progress');
+  const progressText = document.getElementById('ppi-progress-text');
+  
+  if (progressBar) progressBar.style.width = percentage + '%';
+  if (progressText) progressText.textContent = `${completed}/${total}`;
+}
+
+// Aggiorna il progresso PaP
+function updatePAPProgress() {
+  const completed = Object.values(papData).filter(val => val !== null).length;
+  const total = Object.keys(papData).length;
+  const percentage = (completed / total) * 100;
+  
+  const progressBar = document.getElementById('pap-progress');
+  const progressText = document.getElementById('pap-progress-text');
+  
+  if (progressBar) progressBar.style.width = percentage + '%';
+  if (progressText) progressText.textContent = `${completed}/${total}`;
+}
+
+// Calcola il punteggio PPI
+function calculatePPI() {
+  const completed = Object.values(ppiData).filter(val => val !== null).length;
+  const resultsDiv = document.getElementById('ppi-results');
+  
+  if (completed === Object.keys(ppiData).length) {
+    const totalScore = Object.values(ppiData).reduce((sum, val) => sum + val, 0);
+    
+    let interpretation = '';
+    let description = '';
+    
+    if (totalScore <= 4) {
+      interpretation = 'Buona prognosi';
+      description = 'Sopravvivenza >6 settimane (probabilità >70%)';
+    } else {
+      interpretation = 'Prognosi riservata';
+      description = 'Sopravvivenza ≤3 settimane (probabilità >80%)';
+    }
+    
+    document.getElementById('ppi-score').textContent = totalScore.toFixed(1);
+    document.getElementById('ppi-interpretation').textContent = interpretation;
+    document.getElementById('ppi-description').textContent = description;
+    
+    if (resultsDiv) {
+      resultsDiv.style.display = 'block';
+      resultsDiv.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  } else {
+    if (resultsDiv) resultsDiv.style.display = 'none';
+  }
+}
+
+// Calcola il punteggio PaP
+function calculatePAP() {
+  const completed = Object.values(papData).filter(val => val !== null).length;
+  const resultsDiv = document.getElementById('pap-results');
+  
+  if (completed === Object.keys(papData).length) {
+    const totalScore = Object.values(papData).reduce((sum, val) => sum + val, 0);
+    
+    let interpretation = '';
+    let description = '';
+    let group = '';
+    
+    if (totalScore <= 5.5) {
+      group = 'A';
+      interpretation = 'Buona prognosi';
+      description = 'Sopravvivenza >30 giorni (probabilità >70%)';
+    } else if (totalScore <= 11) {
+      group = 'B';
+      interpretation = 'Prognosi intermedia';
+      description = 'Sopravvivenza incerta (30-70% probabilità)';
+    } else {
+      group = 'C';
+      interpretation = 'Prognosi riservata';
+      description = 'Sopravvivenza <30 giorni (probabilità >70%)';
+    }
+    
+    document.getElementById('pap-score').textContent = totalScore.toFixed(1);
+    document.getElementById('pap-interpretation').textContent = `Gruppo ${group} - ${interpretation}`;
+    document.getElementById('pap-description').textContent = description;
+    
+    if (resultsDiv) {
+      resultsDiv.style.display = 'block';
+      resultsDiv.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  } else {
+    if (resultsDiv) resultsDiv.style.display = 'none';
+  }
+}
+
+// Reset del form PPI
+function resetPPI() {
+  if (confirm('Sei sicuro di voler azzerare tutti i dati del PPI?')) {
+    // Reset dei dati
+    ppiData = { pps: null, oral: null, edema: null, dyspnea: null, delirium: null };
+    
+    // Reset del nome paziente
+    const patientName = document.getElementById('ppi-patient-name');
+    if (patientName) patientName.value = '';
+    
+    // Reset del progresso
+    updatePPIProgress();
+    
+    // Nasconde i risultati
+    const resultsDiv = document.getElementById('ppi-results');
+    if (resultsDiv) resultsDiv.style.display = 'none';
+    
+    // Rimuove tutte le selezioni
+    document.querySelectorAll('#ppi-home .radio-option').forEach(option => {
+      option.classList.remove('selected');
+    });
+    
+    // Rimuove il completed dai form items
+    document.querySelectorAll('#ppi-home .form-item').forEach(item => {
+      item.classList.remove('completed');
+    });
+  }
+}
+
+// Reset del form PaP
+function resetPAP() {
+  if (confirm('Sei sicuro di voler azzerare tutti i dati del PaP Score?')) {
+    // Reset dei dati
+    papData = { dyspnea: null, anorexia: null, karnofsky: null, wbc: null, lymphocytes: null, prediction: null };
+    
+    // Reset del nome paziente
+    const patientName = document.getElementById('pap-patient-name');
+    if (patientName) patientName.value = '';
+    
+    // Reset del progresso
+    updatePAPProgress();
+    
+    // Nasconde i risultati
+    const resultsDiv = document.getElementById('pap-results');
+    if (resultsDiv) resultsDiv.style.display = 'none';
+    
+    // Rimuove tutte le selezioni
+    document.querySelectorAll('#pap-home .radio-option').forEach(option => {
+      option.classList.remove('selected');
+    });
+    
+    // Rimuove il completed dai form items
+    document.querySelectorAll('#pap-home .form-item').forEach(item => {
+      item.classList.remove('completed');
+    });
+  }
+}
+
+// Genera report PPI
+function generatePPIReport() {
+  const patientName = document.getElementById('ppi-patient-name').value || 'Paziente non specificato';
+  const date = document.getElementById('ppi-date').value || new Date().toISOString().split('T')[0];
+  
+  const completed = Object.values(ppiData).filter(val => val !== null).length;
+  if (completed < Object.keys(ppiData).length) {
+    alert('Completa tutti i parametri prima di generare il report');
+    return;
+  }
+  
+  const totalScore = Object.values(ppiData).reduce((sum, val) => sum + val, 0);
+  const interpretation = totalScore <= 4 ? 
+    'Buona prognosi - Sopravvivenza >6 settimane (probabilità >70%)' : 
+    'Prognosi riservata - Sopravvivenza ≤3 settimane (probabilità >80%)';
+  
+  const reportContent = `
+REPORT PPI - PALLIATIVE PERFORMANCE INDEX
+==========================================
+
+Paziente: ${patientName}
+Data valutazione: ${new Date(date).toLocaleDateString('it-IT')}
+
+PARAMETRI VALUTATI:
+• Palliative Performance Scale: ${ppiData.pps} punti
+• Assunzione orale: ${ppiData.oral} punti  
+• Edema: ${ppiData.edema} punti
+• Dispnea a riposo: ${ppiData.dyspnea} punti
+• Delirium: ${ppiData.delirium} punti
+
+PUNTEGGIO TOTALE: ${totalScore.toFixed(1)} punti
+
+INTERPRETAZIONE:
+${interpretation}
+
+Report generato da Medbox.it - Strumenti di Prognosi
+Data di generazione: ${new Date().toLocaleDateString('it-IT')}
+
+Valutato da: [Nome del medico]
+Firma: ____________________
+  `;
+  
+  downloadReport(reportContent, `Report_PPI_${patientName.replace(/\s+/g, '_')}_${date}.txt`);
+}
+
+// Genera report PaP
+function generatePAPReport() {
+  const patientName = document.getElementById('pap-patient-name').value || 'Paziente non specificato';
+  const date = document.getElementById('pap-date').value || new Date().toISOString().split('T')[0];
+  
+  const completed = Object.values(papData).filter(val => val !== null).length;
+  if (completed < Object.keys(papData).length) {
+    alert('Completa tutti i parametri prima di generare il report');
+    return;
+  }
+  
+  const totalScore = Object.values(papData).reduce((sum, val) => sum + val, 0);
+  let group = totalScore <= 5.5 ? 'A' : totalScore <= 11 ? 'B' : 'C';
+  
+  const interpretation = group === 'A' ? 'Buona prognosi - Sopravvivenza >30 giorni (probabilità >70%)' :
+    group === 'B' ? 'Prognosi intermedia - Sopravvivenza incerta (30-70% probabilità)' :
+    'Prognosi riservata - Sopravvivenza <30 giorni (probabilità >70%)';
+  
+  const reportContent = `
+REPORT PAP SCORE - PALLIATIVE PROGNOSTIC SCORE
+==============================================
+
+Paziente: ${patientName}
+Data valutazione: ${new Date(date).toLocaleDateString('it-IT')}
+
+PARAMETRI VALUTATI:
+• Dispnea: ${papData.dyspnea} punti
+• Anoressia: ${papData.anorexia} punti
+• Karnofsky Performance Status: ${papData.karnofsky} punti
+• Leucociti totali: ${papData.wbc} punti
+• Percentuale Linfociti: ${papData.lymphocytes} punti
+• Predizione clinica: ${papData.prediction} punti
+
+PUNTEGGIO TOTALE: ${totalScore.toFixed(1)} punti
+GRUPPO PROGNOSTICO: ${group}
+
+INTERPRETAZIONE:
+${interpretation}
+
+Report generato da Medbox.it - Strumenti di Prognosi
+Data di generazione: ${new Date().toLocaleDateString('it-IT')}
+
+Valutato da: [Nome del medico]
+Firma: ____________________
+  `;
+  
+  downloadReport(reportContent, `Report_PaP_${patientName.replace(/\s+/g, '_')}_${date}.txt`);
+}
+
+// Funzione per scaricare il report
+function downloadReport(content, filename) {
+  const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+// Funzioni di stampa
+function printPPI() {
+  const patientName = document.getElementById('ppi-patient-name').value || 'Paziente non specificato';
+  const date = document.getElementById('ppi-date').value || new Date().toISOString().split('T')[0];
+  
+  const completed = Object.values(ppiData).filter(val => val !== null).length;
+  if (completed < Object.keys(ppiData).length) {
+    alert('Completa tutti i parametri prima di stampare');
+    return;
+  }
+  
+  const totalScore = Object.values(ppiData).reduce((sum, val) => sum + val, 0);
+  const interpretation = totalScore <= 4 ? 
+    'Buona prognosi - Sopravvivenza >6 settimane (probabilità >70%)' : 
+    'Prognosi riservata - Sopravvivenza ≤3 settimane (probabilità >80%)';
+  
+  const printContent = `
+    <div style="font-family: Arial, sans-serif; max-width: 800px; margin: 0 auto; padding: 20px;">
+      <h1 style="color: #fd7e14; text-align: center; margin-bottom: 30px;">
+        PPI - Palliative Performance Index
+      </h1>
+      
+      <div style="background: #f8f9fa; padding: 20px; border-radius: 8px; margin-bottom: 30px;">
+        <h3>Dati Paziente</h3>
+        <p><strong>Nome:</strong> ${patientName}</p>
+        <p><strong>Data valutazione:</strong> ${new Date(date).toLocaleDateString('it-IT')}</p>
+      </div>
+      
+      <div style="margin-bottom: 30px;">
+        <h3>Parametri Valutati</h3>
+        <table style="width: 100%; border-collapse: collapse; margin: 20px 0;">
+          <thead>
+            <tr style="background: #fd7e14; color: white;">
+              <th style="padding: 10px; border: 1px solid #ddd;">Parametro</th>
+              <th style="padding: 10px; border: 1px solid #ddd;">Punteggio</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td style="padding: 10px; border: 1px solid #ddd;">Palliative Performance Scale</td><td style="padding: 10px; border: 1px solid #ddd;">${ppiData.pps}</td></tr>
+            <tr><td style="padding: 10px; border: 1px solid #ddd;">Assunzione orale</td><td style="padding: 10px; border: 1px solid #ddd;">${ppiData.oral}</td></tr>
+            <tr><td style="padding: 10px; border: 1px solid #ddd;">Edema</td><td style="padding: 10px; border: 1px solid #ddd;">${ppiData.edema}</td></tr>
+            <tr><td style="padding: 10px; border: 1px solid #ddd;">Dispnea a riposo</td><td style="padding: 10px; border: 1px solid #ddd;">${ppiData.dyspnea}</td></tr>
+            <tr><td style="padding: 10px; border: 1px solid #ddd;">Delirium</td><td style="padding: 10px; border: 1px solid #ddd;">${ppiData.delirium}</td></tr>
+            <tr style="background: #fff3e0; font-weight: bold;">
+              <td style="padding: 10px; border: 1px solid #ddd;">TOTALE</td>
+              <td style="padding: 10px; border: 1px solid #ddd;">${totalScore.toFixed(1)}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      
+      <div style="background: #e8f5e8; padding: 20px; border-radius: 8px; margin-bottom: 30px;">
+        <h3>Interpretazione</h3>
+        <p><strong>${interpretation}</strong></p>
+      </div>
+      
+      <div style="margin-top: 50px;">
+        <p>Data di stampa: ${new Date().toLocaleDateString('it-IT')}</p>
+        <p>Valutato da: ________________________</p>
+        <p>Firma: ________________________</p>
+      </div>
+    </div>
+  `;
+  
+  openPrintWindow(printContent);
+}
+
+function printPAP() {
+  const patientName = document.getElementById('pap-patient-name').value || 'Paziente non specificato';
+  const date = document.getElementById('pap-date').value || new Date().toISOString().split('T')[0];
+  
+  const completed = Object.values(papData).filter(val => val !== null).length;
+  if (completed < Object.keys(papData).length) {
+    alert('Completa tutti i parametri prima di stampare');
+    return;
+  }
+  
+  const totalScore = Object.values(papData).reduce((sum, val) => sum + val, 0);
+  let group = totalScore <= 5.5 ? 'A' : totalScore <= 11 ? 'B' : 'C';
+  
+  const interpretation = group === 'A' ? 'Buona prognosi - Sopravvivenza >30 giorni (probabilità >70%)' :
+    group === 'B' ? 'Prognosi intermedia - Sopravvivenza incerta (30-70% probabilità)' :
+    'Prognosi riservata - Sopravvivenza <30 giorni (probabilità >70%)';
+  
+  const printContent = `
+    <div style="font-family: Arial, sans-serif; max-width: 800px; margin: 0 auto; padding: 20px;">
+      <h1 style="color: #9b59b6; text-align: center; margin-bottom: 30px;">
+        PaP Score - Palliative Prognostic Score
+      </h1>
+      
+      <div style="background: #f8f9fa; padding: 20px; border-radius: 8px; margin-bottom: 30px;">
+        <h3>Dati Paziente</h3>
+        <p><strong>Nome:</strong> ${patientName}</p>
+        <p><strong>Data valutazione:</strong> ${new Date(date).toLocaleDateString('it-IT')}</p>
+      </div>
+      
+      <div style="margin-bottom: 30px;">
+        <h3>Parametri Valutati</h3>
+        <table style="width: 100%; border-collapse: collapse; margin: 20px 0;">
+          <thead>
+            <tr style="background: #9b59b6; color: white;">
+              <th style="padding: 10px; border: 1px solid #ddd;">Parametro</th>
+              <th style="padding: 10px; border: 1px solid #ddd;">Punteggio</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td style="padding: 10px; border: 1px solid #ddd;">Dispnea</td><td style="padding: 10px; border: 1px solid #ddd;">${papData.dyspnea}</td></tr>
+            <tr><td style="padding: 10px; border: 1px solid #ddd;">Anoressia</td><td style="padding: 10px; border: 1px solid #ddd;">${papData.anorexia}</td></tr>
+            <tr><td style="padding: 10px; border: 1px solid #ddd;">Karnofsky Performance Status</td><td style="padding: 10px; border: 1px solid #ddd;">${papData.karnofsky}</td></tr>
+            <tr><td style="padding: 10px; border: 1px solid #ddd;">Leucociti totali</td><td style="padding: 10px; border: 1px solid #ddd;">${papData.wbc}</td></tr>
+            <tr><td style="padding: 10px; border: 1px solid #ddd;">Percentuale Linfociti</td><td style="padding: 10px; border: 1px solid #ddd;">${papData.lymphocytes}</td></tr>
+            <tr><td style="padding: 10px; border: 1px solid #ddd;">Predizione clinica</td><td style="padding: 10px; border: 1px solid #ddd;">${papData.prediction}</td></tr>
+            <tr style="background: #f3e5f5; font-weight: bold;">
+              <td style="padding: 10px; border: 1px solid #ddd;">TOTALE</td>
+              <td style="padding: 10px; border: 1px solid #ddd;">${totalScore.toFixed(1)}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      
+      <div style="background: #e8f5e8; padding: 20px; border-radius: 8px; margin-bottom: 30px;">
+        <h3>Interpretazione</h3>
+        <p><strong>Gruppo ${group} - ${interpretation}</strong></p>
+      </div>
+      
+      <div style="margin-top: 50px;">
+        <p>Data di stampa: ${new Date().toLocaleDateString('it-IT')}</p>
+        <p>Valutato da: ________________________</p>
+        <p>Firma: ________________________</p>
+      </div>
+    </div>
+  `;
+  
+  openPrintWindow(printContent);
+}
+
+// Funzione per aprire finestra di stampa
+function openPrintWindow(content) {
+  const printWindow = window.open('', '_blank');
+  printWindow.document.write(`
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <title>Stampa - Medbox.it</title>
+      <style>
+        @media print {
+          body { margin: 0; }
+          .no-print { display: none; }
+        }
+      </style>
+    </head>
+    <body>
+      ${content}
+      <script>
+        window.onload = function() {
+          window.print();
+          window.onafterprint = function() {
+            window.close();
+          }
+        }
+      </script>
+    </body>
+    </html>
+  `);
+  printWindow.document.close();
+}
+
+// Salvataggio automatico in localStorage
+function savePPIData() {
+  const data = {
+    ...ppiData,
+    patientName: document.getElementById('ppi-patient-name').value,
+    date: document.getElementById('ppi-date').value,
+    timestamp: new Date().toISOString()
+  };
+  localStorage.setItem('medbox_ppi_data', JSON.stringify(data));
+}
+
+function savePAPData() {
+  const data = {
+    ...papData,
+    patientName: document.getElementById('pap-patient-name').value,
+    date: document.getElementById('pap-date').value,
+    timestamp: new Date().toISOString()
+  };
+  localStorage.setItem('medbox_pap_data', JSON.stringify(data));
+}
+
+// Caricamento dati salvati
+function loadPPIData() {
+  const saved = localStorage.getItem('medbox_ppi_data');
+  if (saved) {
+    const data = JSON.parse(saved);
+    
+    // Carica i dati paziente
+    if (data.patientName) document.getElementById('ppi-patient-name').value = data.patientName;
+    if (data.date) document.getElementById('ppi-date').value = data.date;
+    
+    // Carica i valori dei parametri
+    Object.keys(ppiData).forEach(key => {
+      if (data[key] !== null && data[key] !== undefined) {
+        ppiData[key] = data[key];
+        // Trova e seleziona l'opzione corrispondente
+        const item = document.getElementById(`ppi-${key}-item`);
+        if (item) {
+          const options = item.querySelectorAll('.radio-option');
+          options.forEach(option => {
+            const span = option.querySelector('span');
+            if (span && span.textContent.includes(`(${data[key]} punt`)) {
+              option.classList.add('selected');
+              item.classList.add('completed');
+            }
+          });
+        }
+      }
+    });
+    
+    updatePPIProgress();
+    calculatePPI();
+  }
+}
+
+function loadPAPData() {
+  const saved = localStorage.getItem('medbox_pap_data');
+  if (saved) {
+    const data = JSON.parse(saved);
+    
+    // Carica i dati paziente
+    if (data.patientName) document.getElementById('pap-patient-name').value = data.patientName;
+    if (data.date) document.getElementById('pap-date').value = data.date;
+    
+    // Carica i valori dei parametri
+    Object.keys(papData).forEach(key => {
+      if (data[key] !== null && data[key] !== undefined) {
+        papData[key] = data[key];
+        // Trova e seleziona l'opzione corrispondente
+        const item = document.getElementById(`pap-${key}-item`);
+        if (item) {
+          const options = item.querySelectorAll('.radio-option');
+          options.forEach(option => {
+            const span = option.querySelector('span');
+            if (span && span.textContent.includes(`(${data[key]} punt`)) {
+              option.classList.add('selected');
+              item.classList.add('completed');
+            }
+          });
+        }
+      }
+    });
+    
+    updatePAPProgress();
+    calculatePAP();
+  }
+}
+
+// Event listeners per salvataggio automatico
+document.addEventListener('DOMContentLoaded', function() {
+  // Carica dati salvati all'avvio
+  setTimeout(() => {
+    loadPPIData();
+    loadPAPData();
+  }, 100);
+  
+  // Salva automaticamente quando si cambia il nome paziente o la data
+  const ppiPatientName = document.getElementById('ppi-patient-name');
+  const ppiDate = document.getElementById('ppi-date');
+  const papPatientName = document.getElementById('pap-patient-name');
+  const papDate = document.getElementById('pap-date');
+  
+  if (ppiPatientName) ppiPatientName.addEventListener('input', savePPIData);
+  if (ppiDate) ppiDate.addEventListener('change', savePPIData);
+  if (papPatientName) papPatientName.addEventListener('input', savePAPData);
+  if (papDate) papDate.addEventListener('change', savePAPData);
+});
+
+// Override delle funzioni di selezione per includere il salvataggio
+const originalSelectPPI = selectPPI;
+selectPPI = function(parameter, value) {
+  originalSelectPPI(parameter, value);
+  savePPIData();
+};
+
+const originalSelectPAP = selectPAP;
+selectPAP = function(parameter, value) {
+  originalSelectPAP(parameter, value);
+  savePAPData();
+};
+

--- a/gestione-sintomi/js/prognosi.js
+++ b/gestione-sintomi/js/prognosi.js
@@ -68,40 +68,68 @@ function openPAPVisualize() {
 
 // Funzioni per navigazione PPI
 function switchPPIMode(mode) {
-  // Rimuove active da tutti i bottoni
+  // Rimuove active da tutti i bottoni PPI
   document.querySelectorAll('#ppi-home .mode-btn').forEach(btn => {
     btn.classList.remove('active');
   });
-  
-  // Nasconde tutte le sezioni
+
+  // Nasconde tutte le sezioni PPI
   document.querySelectorAll('#ppi-home .content-section').forEach(section => {
     section.classList.remove('active');
   });
-  
-  // Attiva il bottone selezionato
-  event.target.classList.add('active');
-  
+
+  // Trova il bottone cliccato e lo attiva
+  const clickedButton = event ? event.target.closest('.mode-btn') : null;
+  if (clickedButton) {
+    clickedButton.classList.add('active');
+  } else {
+    // Fallback: attiva il primo bottone corrispondente al mode
+    const modeButtons = document.querySelectorAll('#ppi-home .mode-btn');
+    modeButtons.forEach(btn => {
+      if (btn.textContent.toLowerCase().includes(mode === 'compile' ? 'compila' : 'visualizza')) {
+        btn.classList.add('active');
+      }
+    });
+  }
+
   // Mostra la sezione corrispondente
-  document.getElementById(`${mode}-section`).classList.add('active');
+  const targetSection = document.querySelector(`#ppi-home #ppi-${mode}-section`);
+  if (targetSection) {
+    targetSection.classList.add('active');
+  }
 }
 
 // Funzioni per navigazione PaP
 function switchPAPMode(mode) {
-  // Rimuove active da tutti i bottoni
+  // Rimuove active da tutti i bottoni PaP
   document.querySelectorAll('#pap-home .mode-btn').forEach(btn => {
     btn.classList.remove('active');
   });
-  
-  // Nasconde tutte le sezioni
+
+  // Nasconde tutte le sezioni PaP
   document.querySelectorAll('#pap-home .content-section').forEach(section => {
     section.classList.remove('active');
   });
-  
-  // Attiva il bottone selezionato
-  event.target.classList.add('active');
-  
+
+  // Trova il bottone cliccato e lo attiva
+  const clickedButton = event ? event.target.closest('.mode-btn') : null;
+  if (clickedButton) {
+    clickedButton.classList.add('active');
+  } else {
+    // Fallback: attiva il primo bottone corrispondente al mode
+    const modeButtons = document.querySelectorAll('#pap-home .mode-btn');
+    modeButtons.forEach(btn => {
+      if (btn.textContent.toLowerCase().includes(mode === 'compile' ? 'compila' : 'visualizza')) {
+        btn.classList.add('active');
+      }
+    });
+  }
+
   // Mostra la sezione corrispondente
-  document.getElementById(`${mode}-section`).classList.add('active');
+  const targetSection = document.querySelector(`#pap-home #pap-${mode}-section`);
+  if (targetSection) {
+    targetSection.classList.add('active');
+  }
 }
 
 // Funzione per selezionare opzioni PPI

--- a/gestione-sintomi/js/prognosi.js
+++ b/gestione-sintomi/js/prognosi.js
@@ -443,6 +443,42 @@ function downloadReport(content, filename) {
 }
 
 // Funzioni di stampa
+function printPPIForm() {
+  const scale = document.querySelector('#ppi-visualize-section .scale-reference').cloneNode(true);
+  const btn = scale.querySelector('.no-print');
+  if (btn) btn.remove();
+  const content = `
+    <div style="font-family: Arial, sans-serif; max-width: 800px; margin: 0 auto; padding:20px;">
+      ${scale.innerHTML}
+    </div>
+    <style>
+      table{width:100%;border-collapse:collapse;}
+      th,td{border:1px solid #ddd;padding:8px;text-align:left;}
+      th{background:#fd7e14;color:#fff;}
+      tbody tr:nth-child(even){background:#f8f9fa;}
+      .interpretation-box{margin-top:20px;padding:15px;border-left:4px solid #fd7e14;background:#fff3e0;}
+    </style>`;
+  openPrintWindow(content);
+}
+
+function printPAPForm() {
+  const scale = document.querySelector('#pap-visualize-section .scale-reference').cloneNode(true);
+  const btn = scale.querySelector('.no-print');
+  if (btn) btn.remove();
+  const content = `
+    <div style="font-family: Arial, sans-serif; max-width: 800px; margin: 0 auto; padding:20px;">
+      ${scale.innerHTML}
+    </div>
+    <style>
+      table{width:100%;border-collapse:collapse;}
+      th,td{border:1px solid #ddd;padding:8px;text-align:left;}
+      th{background:#9b59b6;color:#fff;}
+      tbody tr:nth-child(even){background:#f8f9fa;}
+      .interpretation-box{margin-top:20px;padding:15px;border-left:4px solid #9b59b6;background:#f3e5f5;}
+    </style>`;
+  openPrintWindow(content);
+}
+
 function printPPI() {
   const patientName = document.getElementById('ppi-patient-name').value || 'Paziente non specificato';
   const date = document.getElementById('ppi-date').value || new Date().toISOString().split('T')[0];

--- a/gestione-sintomi/js/strumenti-valutazione.js
+++ b/gestione-sintomi/js/strumenti-valutazione.js
@@ -90,12 +90,30 @@ function loadCategoryContent(categoryName) {
       ]
     },
     'prognosi': {
-      title: 'Strumenti Prognostici',
-      icon: '📈',
-      description: 'Strumenti per la valutazione prognostica',
+      title: 'Strumenti di Prognosi',
+      icon: '⏳',
+      description: "Scale prognostiche per la valutazione dell'aspettativa di vita",
       tools: [
-        { name: 'PPI', subtitle: 'Palliative Prognostic Index', description: 'Indice prognostico per predire la sopravvivenza a 3 e 6 settimane in pazienti oncologici.', available: false },
-        { name: 'PaP Score', subtitle: 'Palliative Prognostic Score', description: 'Score prognostico che combina parametri clinici e di laboratorio per la predizione di sopravvivenza.', available: false }
+        {
+          name: 'PPI',
+          subtitle: 'Palliative Performance Index',
+          description: 'Strumento prognostico per stimare la sopravvivenza nei pazienti in cure palliative.',
+          available: true,
+          actions: [
+            { name: 'Compila', class: 'btn-primary', icon: 'fas fa-edit', action: 'openPPICompile()' },
+            { name: 'Visualizza', class: 'btn-outline-primary', icon: 'fas fa-table', action: 'openPPIVisualize()' }
+          ]
+        },
+        {
+          name: 'PaP Score',
+          subtitle: 'Palliative Prognostic Score',
+          description: 'Score prognostico multidimensionale che combina valutazione clinica e parametri laboratoristici.',
+          available: true,
+          actions: [
+            { name: 'Compila', class: 'btn-primary', icon: 'fas fa-edit', action: 'openPAPCompile()' },
+            { name: 'Visualizza', class: 'btn-outline-primary', icon: 'fas fa-table', action: 'openPAPVisualize()' }
+          ]
+        }
       ]
     },
     'multidimensionale': {
@@ -277,6 +295,39 @@ function openESASCompile() {
 function openESASVisualize() {
   navigateToSection('esas-home');
   if (typeof switchMode === 'function') switchMode('visualize');
+}
+
+// Funzioni per navigazione Prognosi
+function openPrognosiHome() {
+  navigateToSection('prognosi-home');
+  if (typeof switchPrognosiMode === 'function') switchPrognosiMode('tools');
+}
+
+function openPrognosiReference() {
+  navigateToSection('prognosi-home');
+  if (typeof switchPrognosiMode === 'function') switchPrognosiMode('reference');
+}
+
+// Funzioni per PPI
+function openPPICompile() {
+  navigateToSection('ppi-home');
+  if (typeof switchPPIMode === 'function') switchPPIMode('compile');
+}
+
+function openPPIVisualize() {
+  navigateToSection('ppi-home');
+  if (typeof switchPPIMode === 'function') switchPPIMode('visualize');
+}
+
+// Funzioni per PaP Score
+function openPAPCompile() {
+  navigateToSection('pap-home');
+  if (typeof switchPAPMode === 'function') switchPAPMode('compile');
+}
+
+function openPAPVisualize() {
+  navigateToSection('pap-home');
+  if (typeof switchPAPMode === 'function') switchPAPMode('visualize');
 }
 
 // Funzioni IDC-PAL

--- a/gestione-sintomi/js/strumenti-valutazione.js
+++ b/gestione-sintomi/js/strumenti-valutazione.js
@@ -297,16 +297,6 @@ function openESASVisualize() {
   if (typeof switchMode === 'function') switchMode('visualize');
 }
 
-// Funzioni per navigazione Prognosi
-function openPrognosiHome() {
-  navigateToSection('prognosi-home');
-  if (typeof switchPrognosiMode === 'function') switchPrognosiMode('tools');
-}
-
-function openPrognosiReference() {
-  navigateToSection('prognosi-home');
-  if (typeof switchPrognosiMode === 'function') switchPrognosiMode('reference');
-}
 
 // Funzioni per PPI
 function openPPICompile() {

--- a/gestione-sintomi/js/strumenti-valutazione.js
+++ b/gestione-sintomi/js/strumenti-valutazione.js
@@ -89,33 +89,6 @@ function loadCategoryContent(categoryName) {
         { name: 'BADL', subtitle: 'Basic Activities of Daily Living', description: 'Valutazione delle attività di base della vita quotidiana con sistema di scoring automatico.', available: true, action: 'openPerfModal("badl")' }
       ]
     },
-    'prognosi': {
-      title: 'Strumenti di Prognosi',
-      icon: '⏳',
-      description: "Scale prognostiche per la valutazione dell'aspettativa di vita",
-      tools: [
-        {
-          name: 'PPI',
-          subtitle: 'Palliative Performance Index',
-          description: 'Strumento prognostico per stimare la sopravvivenza nei pazienti in cure palliative.',
-          available: true,
-          actions: [
-            { name: 'Compila', class: 'btn-primary', icon: 'fas fa-edit', action: 'openPPICompile()' },
-            { name: 'Visualizza', class: 'btn-outline-primary', icon: 'fas fa-table', action: 'openPPIVisualize()' }
-          ]
-        },
-        {
-          name: 'PaP Score',
-          subtitle: 'Palliative Prognostic Score',
-          description: 'Score prognostico multidimensionale che combina valutazione clinica e parametri laboratoristici.',
-          available: true,
-          actions: [
-            { name: 'Compila', class: 'btn-primary', icon: 'fas fa-edit', action: 'openPAPCompile()' },
-            { name: 'Visualizza', class: 'btn-outline-primary', icon: 'fas fa-table', action: 'openPAPVisualize()' }
-          ]
-        }
-      ]
-    },
     'multidimensionale': {
       title: 'Valutazione Multidimensionale',
       icon: '📋',
@@ -318,6 +291,17 @@ function openPAPCompile() {
 function openPAPVisualize() {
   navigateToSection('pap-home');
   if (typeof switchPAPMode === 'function') switchPAPMode('visualize');
+}
+
+// Funzioni per Prognosi
+function openPrognosiHome() {
+  navigateToSection('prognosi-home');
+  if (typeof switchPrognosiMode === 'function') switchPrognosiMode('tools');
+}
+
+function openPrognosiReference() {
+  navigateToSection('prognosi-home');
+  if (typeof switchPrognosiMode === 'function') switchPrognosiMode('reference');
 }
 
 // Funzioni IDC-PAL

--- a/gestione-sintomi/strumenti-prognosi.php
+++ b/gestione-sintomi/strumenti-prognosi.php
@@ -1,327 +1,527 @@
 <?php
 // strumenti-prognosi.php
 ?>
-<section id="prognosi-home" class="sintomo-section p-4" data-sintomo="prognosi-home" style="display:none;">
+<link rel="stylesheet" href="css/prognosi.css">
+
+<section id="prognosi-home" class="p-4" style="display:none;">
   <div class="prognosi-container">
-    <h5 class="mb-3"><i class="fas fa-chart-line me-2"></i>Strumenti di Prognosi</h5>
-    <p class="text-muted">Scale prognostiche validate per la valutazione dell'aspettativa di vita in cure palliative</p>
-    <div class="prognosi-grid">
-      <div class="prognosi-card ppi" onclick="openProgModal('ppi')">
-        <div class="card-header">
-          <div class="card-icon">PPI</div>
-          <div>
-            <div class="card-title">PPI</div>
-            <div class="card-subtitle">Palliative Performance Index</div>
+    <div class="prognosi-header">
+      <h1><i class="fas fa-hourglass-half me-2"></i>Strumenti di Prognosi</h1>
+      <p class="text-muted">Scale prognostiche validate per la valutazione dell'aspettativa di vita in cure palliative</p>
+    </div>
+
+    <div class="mode-selector mb-4">
+      <a href="#" class="mode-btn active" onclick="switchPrognosiMode('tools')">
+        <i class="fas fa-calculator me-2"></i>Strumenti
+      </a>
+      <a href="#" class="mode-btn" onclick="switchPrognosiMode('reference')">
+        <i class="fas fa-book-medical me-2"></i>Riferimenti
+      </a>
+    </div>
+
+    <!-- Sezione Strumenti -->
+    <div id="tools-section" class="content-section active">
+      <div class="prognosi-grid">
+        <div class="tool-card tool-card-compact h-100">
+          <div class="tool-header">
+            <div class="tool-icon-large ppi-icon">
+              <span class="tool-letters">PPI</span>
+            </div>
+            <div class="tool-info">
+              <h4>PPI</h4>
+              <div class="tool-subtitle">Palliative Performance Index</div>
+            </div>
+          </div>
+          
+          <div class="tool-description">
+            Strumento prognostico per stimare la sopravvivenza nei pazienti in cure palliative, basato su 5 parametri clinici facilmente valutabili.
+          </div>
+          
+          <div class="tool-features">
+            <span class="feature-badge">5 parametri</span>
+            <span class="feature-badge">Predizione 3-6 settimane</span>
+            <span class="feature-badge">Validato</span>
+          </div>
+          
+          <div class="tool-actions">
+            <button class="btn btn-primary btn-action" onclick="openPPICompile()">
+              <i class="fas fa-edit me-2"></i>Compila
+            </button>
+            <button class="btn btn-outline-primary btn-action" onclick="openPPIVisualize()">
+              <i class="fas fa-table me-2"></i>Visualizza
+            </button>
           </div>
         </div>
-        <div class="card-description">
-          Strumento prognostico per stimare la sopravvivenza nei pazienti in cure palliative, basato su 5 parametri clinici facilmente valutabili.
+
+        <div class="tool-card tool-card-compact h-100">
+          <div class="tool-header">
+            <div class="tool-icon-large pap-icon">
+              <span class="tool-letters">PaP</span>
+            </div>
+            <div class="tool-info">
+              <h4>PaP Score</h4>
+              <div class="tool-subtitle">Palliative Prognostic Score</div>
+            </div>
+          </div>
+          
+          <div class="tool-description">
+            Score prognostico multidimensionale che combina valutazione clinica e parametri laboratoristici per predire la sopravvivenza a 30 giorni.
+          </div>
+          
+          <div class="tool-features">
+            <span class="feature-badge">6 parametri</span>
+            <span class="feature-badge">3 gruppi rischio</span>
+            <span class="feature-badge">30 giorni</span>
+          </div>
+          
+          <div class="tool-actions">
+            <button class="btn btn-primary btn-action" onclick="openPAPCompile()">
+              <i class="fas fa-edit me-2"></i>Compila
+            </button>
+            <button class="btn btn-outline-primary btn-action" onclick="openPAPVisualize()">
+              <i class="fas fa-table me-2"></i>Visualizza
+            </button>
+          </div>
         </div>
       </div>
-      <div class="prognosi-card pap" onclick="openProgModal('pap')">
-        <div class="card-header">
-          <div class="card-icon">PaP</div>
-          <div>
-            <div class="card-title">PaP Score</div>
-            <div class="card-subtitle">Palliative Prognostic Score</div>
+    </div>
+
+    <!-- Sezione Riferimenti -->
+    <div id="reference-section" class="content-section">
+      <div class="reference-content">
+        <h3>Riferimenti Scientifici</h3>
+        <div class="reference-grid">
+          <div class="reference-card">
+            <h5>Documento AIOM-SICP 2015</h5>
+            <p>"Cure Palliative Precoci e Simultanee" - Linee guida nazionali per l'implementazione delle cure palliative.</p>
+          </div>
+          <div class="reference-card">
+            <h5>Linee Guida NCCN</h5>
+            <p>National Comprehensive Cancer Network guidelines per le cure palliative in oncologia.</p>
+          </div>
+          <div class="reference-card">
+            <h5>Gold Standard Framework</h5>
+            <p>Framework per l'identificazione precoce dei pazienti che necessitano di cure palliative.</p>
+          </div>
+          <div class="reference-card">
+            <h5>EAPC Basic Dataset</h5>
+            <p>Dataset europeo per la valutazione multidimensionale in cure palliative.</p>
           </div>
         </div>
-        <div class="card-description">
-          Score prognostico multidimensionale che combina valutazione clinica e parametri laboratoristici per predire la sopravvivenza a 30 giorni.
+
+        <div class="clinical-criteria mt-4">
+          <h4>Criteri di Eleggibilità per Cure Palliative</h4>
+          <div class="criteria-list">
+            <div class="criteria-item">
+              <i class="fas fa-check-circle text-success"></i>
+              <div>
+                <strong>Neoplasia metastatica</strong>
+                <p>Malattia oncologica in stadio avanzato con metastasi</p>
+              </div>
+            </div>
+            <div class="criteria-item">
+              <i class="fas fa-check-circle text-success"></i>
+              <div>
+                <strong>Performance Status compromesso</strong>
+                <p>ECOG ≥3 o Karnofsky ≤50%</p>
+              </div>
+            </div>
+            <div class="criteria-item">
+              <i class="fas fa-check-circle text-success"></i>
+              <div>
+                <strong>Aspettativa di vita limitata</strong>
+                <p>Prognosi &lt;6-12 mesi</p>
+              </div>
+            </div>
+            <div class="criteria-item">
+              <i class="fas fa-check-circle text-success"></i>
+              <div>
+                <strong>Sintomi non controllati</strong>
+                <p>Alto carico sintomatologico refrattario</p>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
   </div>
 </section>
 
-<!-- Modal PPI -->
-<div id="prog-modal-ppi" class="prog-modal">
-  <div class="prog-modal-content">
-    <span class="prog-close" onclick="closeProgModal('ppi')">&times;</span>
-    <h3>PPI - Palliative Performance Index</h3>
-    <div class="tabs">
-      <button class="tab active" onclick="showProgTab('ppi','compile')">📝 Compila</button>
-      <button class="tab" onclick="showProgTab('ppi','view')">📊 Visualizza Scala</button>
+<!-- Sezione PPI -->
+<section id="ppi-home" class="p-4" style="display:none;">
+  <div class="ppi-container">
+    <div class="ppi-header">
+      <h1><i class="fas fa-hourglass-half me-2"></i>PPI - Palliative Performance Index</h1>
+      <p class="text-muted">Strumento prognostico per stimare la sopravvivenza nei pazienti in cure palliative</p>
     </div>
-    <div id="ppi-compile" class="tab-content active">
-      <div class="patient-info">
-        <h4>Dati Paziente</h4>
-        <input type="text" id="ppi-patient-name" placeholder="Nome paziente" />
-        <input type="date" id="ppi-date" />
-      </div>
-      <div class="form-group">
-        <h4>Compila i 5 parametri del PPI:</h4>
-        <div style="margin-bottom:1rem;">
-          <div class="progress-bar"><div class="progress-fill" id="ppi-progress" style="width:0%"></div></div>
-          <small style="color:#666;">Progresso: <span id="ppi-progress-text">0/5</span> parametri completati</small>
+
+    <div class="mode-selector mb-4">
+      <a href="#" class="mode-btn active" onclick="switchPPIMode('compile')">
+        <i class="fas fa-edit me-2"></i>Compila
+      </a>
+      <a href="#" class="mode-btn" onclick="switchPPIMode('visualize')">
+        <i class="fas fa-table me-2"></i>Visualizza
+      </a>
+    </div>
+
+    <!-- Tab Compila -->
+    <div id="compile-section" class="content-section active">
+      <div class="patient-info-card">
+        <h4><i class="fas fa-user me-2"></i>Dati Paziente</h4>
+        <div class="row">
+          <div class="col-md-6">
+            <input type="text" class="form-control" id="ppi-patient-name" placeholder="Nome paziente">
+          </div>
+          <div class="col-md-6">
+            <input type="date" class="form-control" id="ppi-date">
+          </div>
         </div>
+      </div>
+
+      <div class="form-card">
+        <h4><i class="fas fa-list-check me-2"></i>Parametri PPI</h4>
+        <div class="progress-indicator mb-4">
+          <div class="progress-bar">
+            <div class="progress-fill" id="ppi-progress" style="width: 0%"></div>
+          </div>
+          <small class="text-muted">Progresso: <span id="ppi-progress-text">0/5</span> parametri completati</small>
+        </div>
+        
         <div class="form-item" id="ppi-pps-item">
-          <label>1. Palliative Performance Scale (PPS)</label>
+          <label class="form-label">1. Palliative Performance Scale (PPS)</label>
           <div class="radio-group">
-            <div class="radio-option" onclick="selectPPI('pps',4)"><input type="radio" name="ppi-pps" value="4"><span>10-20% (4 punti)</span></div>
-            <div class="radio-option" onclick="selectPPI('pps',2.5)"><input type="radio" name="ppi-pps" value="2.5"><span>30-50% (2.5 punti)</span></div>
-            <div class="radio-option" onclick="selectPPI('pps',0)"><input type="radio" name="ppi-pps" value="0"><span>>60% (0 punti)</span></div>
+            <div class="radio-option" onclick="selectPPI('pps', 4)">
+              <span>10-20% (4 punti)</span>
+            </div>
+            <div class="radio-option" onclick="selectPPI('pps', 2.5)">
+              <span>30-50% (2.5 punti)</span>
+            </div>
+            <div class="radio-option" onclick="selectPPI('pps', 0)">
+              <span>&gt;60% (0 punti)</span>
+            </div>
           </div>
         </div>
+
         <div class="form-item" id="ppi-oral-item">
-          <label>2. Assunzione orale</label>
+          <label class="form-label">2. Assunzione orale</label>
           <div class="radio-group">
-            <div class="radio-option" onclick="selectPPI('oral',2.5)"><input type="radio" name="ppi-oral" value="2.5"><span>Severamente ridotta (2.5 punti)</span></div>
-            <div class="radio-option" onclick="selectPPI('oral',1)"><input type="radio" name="ppi-oral" value="1"><span>Moderatamente ridotta (1 punto)</span></div>
-            <div class="radio-option" onclick="selectPPI('oral',0)"><input type="radio" name="ppi-oral" value="0"><span>Normale (0 punti)</span></div>
+            <div class="radio-option" onclick="selectPPI('oral', 2.5)">
+              <span>Severamente ridotta (2.5 punti)</span>
+            </div>
+            <div class="radio-option" onclick="selectPPI('oral', 1)">
+              <span>Moderatamente ridotta (1 punto)</span>
+            </div>
+            <div class="radio-option" onclick="selectPPI('oral', 0)">
+              <span>Normale (0 punti)</span>
+            </div>
           </div>
         </div>
+
         <div class="form-item" id="ppi-edema-item">
-          <label>3. Edema</label>
+          <label class="form-label">3. Edema</label>
           <div class="radio-group">
-            <div class="radio-option" onclick="selectPPI('edema',1)"><input type="radio" name="ppi-edema" value="1"><span>Presente (1 punto)</span></div>
-            <div class="radio-option" onclick="selectPPI('edema',0)"><input type="radio" name="ppi-edema" value="0"><span>Assente (0 punti)</span></div>
+            <div class="radio-option" onclick="selectPPI('edema', 1)">
+              <span>Presente (1 punto)</span>
+            </div>
+            <div class="radio-option" onclick="selectPPI('edema', 0)">
+              <span>Assente (0 punti)</span>
+            </div>
           </div>
         </div>
+
         <div class="form-item" id="ppi-dyspnea-item">
-          <label>4. Dispnea a riposo</label>
+          <label class="form-label">4. Dispnea a riposo</label>
           <div class="radio-group">
-            <div class="radio-option" onclick="selectPPI('dyspnea',3.5)"><input type="radio" name="ppi-dyspnea" value="3.5"><span>Presente (3.5 punti)</span></div>
-            <div class="radio-option" onclick="selectPPI('dyspnea',0)"><input type="radio" name="ppi-dyspnea" value="0"><span>Assente (0 punti)</span></div>
+            <div class="radio-option" onclick="selectPPI('dyspnea', 3.5)">
+              <span>Presente (3.5 punti)</span>
+            </div>
+            <div class="radio-option" onclick="selectPPI('dyspnea', 0)">
+              <span>Assente (0 punti)</span>
+            </div>
           </div>
         </div>
+
         <div class="form-item" id="ppi-delirium-item">
-          <label>5. Delirium</label>
+          <label class="form-label">5. Delirium</label>
           <div class="radio-group">
-            <div class="radio-option" onclick="selectPPI('delirium',4)"><input type="radio" name="ppi-delirium" value="4"><span>Presente (4 punti)</span></div>
-            <div class="radio-option" onclick="selectPPI('delirium',0)"><input type="radio" name="ppi-delirium" value="0"><span>Assente (0 punti)</span></div>
+            <div class="radio-option" onclick="selectPPI('delirium', 4)">
+              <span>Presente (4 punti)</span>
+            </div>
+            <div class="radio-option" onclick="selectPPI('delirium', 0)">
+              <span>Assente (0 punti)</span>
+            </div>
           </div>
         </div>
       </div>
-      <div id="ppi-results" class="score-display" style="display:none;">
-        <div class="score-number" id="ppi-score">0</div>
-        <div class="score-interpretation" id="ppi-interpretation">Punteggio PPI</div>
-        <div class="score-description" id="ppi-description">Completa tutti i parametri per la valutazione prognostica</div>
+
+      <div id="ppi-results" class="score-display" style="display: none;">
+        <div class="score-header">
+          <h3>Risultato PPI</h3>
+        </div>
+        <div class="score-content">
+          <div class="score-number" id="ppi-score">0</div>
+          <div class="score-interpretation" id="ppi-interpretation">Punteggio PPI</div>
+          <div class="score-description" id="ppi-description">Completa tutti i parametri per la valutazione prognostica</div>
+        </div>
       </div>
-      <div class="text-center">
-        <button class="btn btn-success" onclick="generateReport('ppi')">📄 Genera Report</button>
-        <button class="btn reset-btn" onclick="resetForm('ppi')">🔄 Azzera</button>
+
+      <div class="action-buttons">
+        <button class="btn btn-success" onclick="generatePPIReport()">
+          <i class="fas fa-download me-2"></i>Genera Report
+        </button>
+        <button class="btn btn-outline-secondary" onclick="resetPPI()">
+          <i class="fas fa-redo me-2"></i>Azzera
+        </button>
+        <button class="btn btn-outline-primary" onclick="printPPI()">
+          <i class="fas fa-print me-2"></i>Stampa
+        </button>
       </div>
     </div>
-    <div id="ppi-view" class="tab-content">
-      <h4>Palliative Performance Index (PPI)</h4>
-      <table class="scale-table">
-        <thead>
-          <tr><th>Parametro</th><th>Valore</th><th>Punteggio</th></tr>
-        </thead>
-        <tbody>
-          <tr><td rowspan="3"><strong>Palliative Performance Scale</strong></td><td>10-20%</td><td>4.0</td></tr>
-          <tr><td>30-50%</td><td>2.5</td></tr>
-          <tr><td>>60%</td><td>0</td></tr>
-          <tr><td rowspan="3"><strong>Assunzione orale</strong></td><td>Severamente ridotta</td><td>2.5</td></tr>
-          <tr><td>Moderatamente ridotta</td><td>1.0</td></tr>
-          <tr><td>Normale</td><td>0</td></tr>
-          <tr><td rowspan="2"><strong>Edema</strong></td><td>Presente</td><td>1.0</td></tr>
-          <tr><td>Assente</td><td>0</td></tr>
-          <tr><td rowspan="2"><strong>Dispnea a riposo</strong></td><td>Presente</td><td>3.5</td></tr>
-          <tr><td>Assente</td><td>0</td></tr>
-          <tr><td rowspan="2"><strong>Delirium</strong></td><td>Presente</td><td>4.0</td></tr>
-          <tr><td>Assente</td><td>0</td></tr>
-        </tbody>
-      </table>
-      <div style="background:#f8f9fa;padding:1.5rem;border-radius:8px;margin-top:1.5rem;">
-        <h5 style="color:#e74c3c;margin-bottom:1rem;">📈 Interpretazione Prognostica:</h5>
-        <ul style="margin:0;padding-left:1.5rem;color:#666;">
-          <li><strong>PPI ≤ 4:</strong> Sopravvivenza >6 settimane (probabilità >70%)</li>
-          <li><strong>PPI > 4:</strong> Sopravvivenza ≤3 settimane (probabilità >80%)</li>
-          <li><strong>Punteggio totale:</strong> 0-15 punti</li>
-          <li><strong>Maggiore è il punteggio, minore è la sopravvivenza attesa</strong></li>
-        </ul>
+
+    <!-- Tab Visualizza -->
+    <div id="visualize-section" class="content-section">
+      <div class="scale-reference">
+        <h4>Palliative Performance Index (PPI) - Scala Completa</h4>
+        <div class="table-responsive">
+          <table class="scale-table">
+            <thead>
+              <tr>
+                <th>Parametro</th>
+                <th>Valore</th>
+                <th>Punteggio</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr><td rowspan="3"><strong>Palliative Performance Scale</strong></td><td>10-20%</td><td>4.0</td></tr>
+              <tr><td>30-50%</td><td>2.5</td></tr>
+              <tr><td>&gt;60%</td><td>0</td></tr>
+              <tr><td rowspan="3"><strong>Assunzione orale</strong></td><td>Severamente ridotta</td><td>2.5</td></tr>
+              <tr><td>Moderatamente ridotta</td><td>1.0</td></tr>
+              <tr><td>Normale</td><td>0</td></tr>
+              <tr><td rowspan="2"><strong>Edema</strong></td><td>Presente</td><td>1.0</td></tr>
+              <tr><td>Assente</td><td>0</td></tr>
+              <tr><td rowspan="2"><strong>Dispnea a riposo</strong></td><td>Presente</td><td>3.5</td></tr>
+              <tr><td>Assente</td><td>0</td></tr>
+              <tr><td rowspan="2"><strong>Delirium</strong></td><td>Presente</td><td>4.0</td></tr>
+              <tr><td>Assente</td><td>0</td></tr>
+            </tbody>
+          </table>
+        </div>
+        
+        <div class="interpretation-box">
+          <h5><i class="fas fa-info-circle me-2"></i>Interpretazione Prognostica</h5>
+          <ul>
+            <li><strong>PPI ≤ 4:</strong> Sopravvivenza &gt;6 settimane (probabilità &gt;70%)</li>
+            <li><strong>PPI &gt; 4:</strong> Sopravvivenza ≤3 settimane (probabilità &gt;80%)</li>
+            <li><strong>Punteggio totale:</strong> 0-15 punti</li>
+            <li><strong>Maggiore è il punteggio, minore è la sopravvivenza attesa</strong></li>
+          </ul>
+        </div>
       </div>
-      <div class="text-center mt-3"><button class="btn btn-primary" onclick="window.print()">Stampa</button></div>
     </div>
   </div>
-</div>
+</section>
 
-<!-- Modal PaP -->
-<div id="prog-modal-pap" class="prog-modal">
-  <div class="prog-modal-content">
-    <span class="prog-close" onclick="closeProgModal('pap')">&times;</span>
-    <h3>PaP Score - Palliative Prognostic Score</h3>
-    <div class="tabs">
-      <button class="tab active" onclick="showProgTab('pap','compile')">📝 Compila</button>
-      <button class="tab" onclick="showProgTab('pap','view')">📊 Visualizza Scala</button>
+<!-- Sezione PaP Score -->
+<section id="pap-home" class="p-4" style="display:none;">
+  <div class="pap-container">
+    <div class="pap-header">
+      <h1><i class="fas fa-chart-line me-2"></i>PaP Score - Palliative Prognostic Score</h1>
+      <p class="text-muted">Score prognostico multidimensionale per la predizione della sopravvivenza a 30 giorni</p>
     </div>
-    <div id="pap-compile" class="tab-content active">
-      <div class="patient-info">
-        <h4>Dati Paziente</h4>
-        <input type="text" id="pap-patient-name" placeholder="Nome paziente" />
-        <input type="date" id="pap-date" />
-      </div>
-      <div class="form-group">
-        <h4>Compila i 6 parametri del PaP Score:</h4>
-        <div style="margin-bottom:1rem;">
-          <div class="progress-bar"><div class="progress-fill" id="pap-progress" style="width:0%"></div></div>
-          <small style="color:#666;">Progresso: <span id="pap-progress-text">0/6</span> parametri completati</small>
+
+    <div class="mode-selector mb-4">
+      <a href="#" class="mode-btn active" onclick="switchPAPMode('compile')">
+        <i class="fas fa-edit me-2"></i>Compila
+      </a>
+      <a href="#" class="mode-btn" onclick="switchPAPMode('visualize')">
+        <i class="fas fa-table me-2"></i>Visualizza
+      </a>
+    </div>
+
+    <!-- Tab Compila -->
+    <div id="compile-section" class="content-section active">
+      <div class="patient-info-card">
+        <h4><i class="fas fa-user me-2"></i>Dati Paziente</h4>
+        <div class="row">
+          <div class="col-md-6">
+            <input type="text" class="form-control" id="pap-patient-name" placeholder="Nome paziente">
+          </div>
+          <div class="col-md-6">
+            <input type="date" class="form-control" id="pap-date">
+          </div>
         </div>
+      </div>
+
+      <div class="form-card">
+        <h4><i class="fas fa-list-check me-2"></i>Parametri PaP Score</h4>
+        <div class="progress-indicator mb-4">
+          <div class="progress-bar">
+            <div class="progress-fill" id="pap-progress" style="width: 0%"></div>
+          </div>
+          <small class="text-muted">Progresso: <span id="pap-progress-text">0/6</span> parametri completati</small>
+        </div>
+        
         <div class="form-item" id="pap-dyspnea-item">
-          <label>1. Dispnea</label>
+          <label class="form-label">1. Dispnea</label>
           <div class="radio-group">
-            <div class="radio-option" onclick="selectPAP('dyspnea',1)"><input type="radio" name="pap-dyspnea" value="1"><span>Sì (1 punto)</span></div>
-            <div class="radio-option" onclick="selectPAP('dyspnea',0)"><input type="radio" name="pap-dyspnea" value="0"><span>No (0 punti)</span></div>
+            <div class="radio-option" onclick="selectPAP('dyspnea', 1)">
+              <span>Sì (1 punto)</span>
+            </div>
+            <div class="radio-option" onclick="selectPAP('dyspnea', 0)">
+              <span>No (0 punti)</span>
+            </div>
           </div>
         </div>
+
         <div class="form-item" id="pap-anorexia-item">
-          <label>2. Anoressia</label>
+          <label class="form-label">2. Anoressia</label>
           <div class="radio-group">
-            <div class="radio-option" onclick="selectPAP('anorexia',1)"><input type="radio" name="pap-anorexia" value="1"><span>Sì (1 punto)</span></div>
-            <div class="radio-option" onclick="selectPAP('anorexia',0)"><input type="radio" name="pap-anorexia" value="0"><span>No (0 punti)</span></div>
+            <div class="radio-option" onclick="selectPAP('anorexia', 1)">
+              <span>Sì (1 punto)</span>
+            </div>
+            <div class="radio-option" onclick="selectPAP('anorexia', 0)">
+              <span>No (0 punti)</span>
+            </div>
           </div>
         </div>
+
         <div class="form-item" id="pap-karnofsky-item">
-          <label>3. Karnofsky Performance Status</label>
+          <label class="form-label">3. Karnofsky Performance Status</label>
           <div class="radio-group">
-            <div class="radio-option" onclick="selectPAP('karnofsky',2.5)"><input type="radio" name="pap-karnofsky" value="2.5"><span>10-20 (2.5 punti)</span></div>
-            <div class="radio-option" onclick="selectPAP('karnofsky',0)"><input type="radio" name="pap-karnofsky" value="0"><span>30-100 (0 punti)</span></div>
+            <div class="radio-option" onclick="selectPAP('karnofsky', 2.5)">
+              <span>10-20 (2.5 punti)</span>
+            </div>
+            <div class="radio-option" onclick="selectPAP('karnofsky', 0)">
+              <span>30-100 (0 punti)</span>
+            </div>
           </div>
         </div>
+
         <div class="form-item" id="pap-wbc-item">
-          <label>4. Leucociti totali</label>
+          <label class="form-label">4. Leucociti totali</label>
           <div class="radio-group">
-            <div class="radio-option" onclick="selectPAP('wbc',1.5)"><input type="radio" name="pap-wbc" value="1.5"><span>>11.000 (1.5 punti)</span></div>
-            <div class="radio-option" onclick="selectPAP('wbc',0.5)"><input type="radio" name="pap-wbc" value="0.5"><span>8.501-11.000 (0.5 punti)</span></div>
-            <div class="radio-option" onclick="selectPAP('wbc',0)"><input type="radio" name="pap-wbc" value="0"><span>≤8.500 (0 punti)</span></div>
+            <div class="radio-option" onclick="selectPAP('wbc', 1.5)">
+              <span>&gt;11.000 (1.5 punti)</span>
+            </div>
+            <div class="radio-option" onclick="selectPAP('wbc', 0.5)">
+              <span>8.501-11.000 (0.5 punti)</span>
+            </div>
+            <div class="radio-option" onclick="selectPAP('wbc', 0)">
+              <span>&le;8.500 (0 punti)</span>
+            </div>
           </div>
         </div>
+
         <div class="form-item" id="pap-lymphocytes-item">
-          <label>5. Percentuale Linfociti</label>
+          <label class="form-label">5. Percentuale Linfociti</label>
           <div class="radio-group">
-            <div class="radio-option" onclick="selectPAP('lymphocytes',2.5)"><input type="radio" name="pap-lymphocytes" value="2.5"><span>0-11.9% (2.5 punti)</span></div>
-            <div class="radio-option" onclick="selectPAP('lymphocytes',1)"><input type="radio" name="pap-lymphocytes" value="1"><span>12-19.9% (1 punto)</span></div>
-            <div class="radio-option" onclick="selectPAP('lymphocytes',0)"><input type="radio" name="pap-lymphocytes" value="0"><span>≥20% (0 punti)</span></div>
+            <div class="radio-option" onclick="selectPAP('lymphocytes', 2.5)">
+              <span>0-11.9% (2.5 punti)</span>
+            </div>
+            <div class="radio-option" onclick="selectPAP('lymphocytes', 1)">
+              <span>12-19.9% (1 punto)</span>
+            </div>
+            <div class="radio-option" onclick="selectPAP('lymphocytes', 0)">
+              <span>&ge;20% (0 punti)</span>
+            </div>
           </div>
         </div>
+
         <div class="form-item" id="pap-prediction-item">
-          <label>6. Predizione clinica di sopravvivenza</label>
+          <label class="form-label">6. Predizione clinica di sopravvivenza</label>
           <div class="radio-group">
-            <div class="radio-option" onclick="selectPAP('prediction',8.5)"><input type="radio" name="pap-prediction" value="8.5"><span>1-2 settimane (8.5 punti)</span></div>
-            <div class="radio-option" onclick="selectPAP('prediction',6)"><input type="radio" name="pap-prediction" value="6"><span>3-4 settimane (6 punti)</span></div>
-            <div class="radio-option" onclick="selectPAP('prediction',4.5)"><input type="radio" name="pap-prediction" value="4.5"><span>5-6 settimane (4.5 punti)</span></div>
-            <div class="radio-option" onclick="selectPAP('prediction',2.5)"><input type="radio" name="pap-prediction" value="2.5"><span>7-10 settimane (2.5 punti)</span></div>
-            <div class="radio-option" onclick="selectPAP('prediction',0)"><input type="radio" name="pap-prediction" value="0"><span>>10 settimane (0 punti)</span></div>
+            <div class="radio-option" onclick="selectPAP('prediction', 8.5)">
+              <span>1-2 settimane (8.5 punti)</span>
+            </div>
+            <div class="radio-option" onclick="selectPAP('prediction', 6)">
+              <span>3-4 settimane (6 punti)</span>
+            </div>
+            <div class="radio-option" onclick="selectPAP('prediction', 4.5)">
+              <span>5-6 settimane (4.5 punti)</span>
+            </div>
+            <div class="radio-option" onclick="selectPAP('prediction', 2.5)">
+              <span>7-10 settimane (2.5 punti)</span>
+            </div>
+            <div class="radio-option" onclick="selectPAP('prediction', 0)">
+              <span>&gt;10 settimane (0 punti)</span>
+            </div>
           </div>
         </div>
       </div>
-      <div id="pap-results" class="score-display" style="display:none;">
-        <div class="score-number" id="pap-score">0</div>
-        <div class="score-interpretation" id="pap-interpretation">Punteggio PaP</div>
-        <div class="score-description" id="pap-description">Completa tutti i parametri per la valutazione prognostica</div>
+
+      <div id="pap-results" class="score-display" style="display: none;">
+        <div class="score-header">
+          <h3>Risultato PaP Score</h3>
+        </div>
+        <div class="score-content">
+          <div class="score-number" id="pap-score">0</div>
+          <div class="score-interpretation" id="pap-interpretation">Punteggio PaP</div>
+          <div class="score-description" id="pap-description">Completa tutti i parametri per la valutazione prognostica</div>
+        </div>
       </div>
-      <div class="text-center">
-        <button class="btn btn-success" onclick="generateReport('pap')">📄 Genera Report</button>
-        <button class="btn reset-btn" onclick="resetForm('pap')">🔄 Azzera</button>
+
+      <div class="action-buttons">
+        <button class="btn btn-success" onclick="generatePAPReport()">
+          <i class="fas fa-download me-2"></i>Genera Report
+        </button>
+        <button class="btn btn-outline-secondary" onclick="resetPAP()">
+          <i class="fas fa-redo me-2"></i>Azzera
+        </button>
+        <button class="btn btn-outline-primary" onclick="printPAP()">
+          <i class="fas fa-print me-2"></i>Stampa
+        </button>
       </div>
     </div>
-    <div id="pap-view" class="tab-content">
-      <h4>Palliative Prognostic Score (PaP)</h4>
-      <table class="scale-table">
-        <thead>
-          <tr><th>Parametro</th><th>Valore</th><th>Punteggio</th></tr>
-        </thead>
-        <tbody>
-          <tr><td rowspan="2"><strong>Dispnea</strong></td><td>Sì</td><td>1.0</td></tr>
-          <tr><td>No</td><td>0</td></tr>
-          <tr><td rowspan="2"><strong>Anoressia</strong></td><td>Sì</td><td>1.0</td></tr>
-          <tr><td>No</td><td>0</td></tr>
-          <tr><td rowspan="2"><strong>Karnofsky Performance Status</strong></td><td>10-20</td><td>2.5</td></tr>
-          <tr><td>30-100</td><td>0</td></tr>
-          <tr><td rowspan="3"><strong>Leucociti totali</strong></td><td>>11.000</td><td>1.5</td></tr>
-          <tr><td>8.501-11.000</td><td>0.5</td></tr>
-          <tr><td>≤8.500</td><td>0</td></tr>
-          <tr><td rowspan="3"><strong>% Linfociti</strong></td><td>0-11.9%</td><td>2.5</td></tr>
-          <tr><td>12-19.9%</td><td>1.0</td></tr>
-          <tr><td>≥20%</td><td>0</td></tr>
-          <tr><td rowspan="5"><strong>Predizione clinica</strong></td><td>1-2 settimane</td><td>8.5</td></tr>
-          <tr><td>3-4 settimane</td><td>6.0</td></tr>
-          <tr><td>5-6 settimane</td><td>4.5</td></tr>
-          <tr><td>7-10 settimane</td><td>2.5</td></tr>
-          <tr><td>>10 settimane</td><td>0</td></tr>
-        </tbody>
-      </table>
-      <div style="background:#f8f9fa;padding:1.5rem;border-radius:8px;margin-top:1.5rem;">
-        <h5 style="color:#9b59b6;margin-bottom:1rem;">📈 Interpretazione Prognostica:</h5>
-        <ul style="margin:0;padding-left:1.5rem;color:#666;">
-          <li><strong>Gruppo A (0-5.5 punti):</strong> Sopravvivenza >30 giorni (probabilità >70%)</li>
-          <li><strong>Gruppo B (5.6-11 punti):</strong> Sopravvivenza incerta (30-70%)</li>
-          <li><strong>Gruppo C (11.1-17.5 punti):</strong> Sopravvivenza <30 giorni (probabilità >70%)</li>
-          <li><strong>Punteggio totale:</strong> 0-17.5 punti</li>
-        </ul>
+
+    <!-- Tab Visualizza -->
+    <div id="visualize-section" class="content-section">
+      <div class="scale-reference">
+        <h4>Palliative Prognostic Score (PaP) - Scala Completa</h4>
+        <div class="table-responsive">
+          <table class="scale-table">
+            <thead>
+              <tr>
+                <th>Parametro</th>
+                <th>Valore</th>
+                <th>Punteggio</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr><td rowspan="2"><strong>Dispnea</strong></td><td>Sì</td><td>1.0</td></tr>
+              <tr><td>No</td><td>0</td></tr>
+              <tr><td rowspan="2"><strong>Anoressia</strong></td><td>Sì</td><td>1.0</td></tr>
+              <tr><td>No</td><td>0</td></tr>
+              <tr><td rowspan="2"><strong>Karnofsky Performance Status</strong></td><td>10-20</td><td>2.5</td></tr>
+              <tr><td>30-100</td><td>0</td></tr>
+              <tr><td rowspan="3"><strong>Leucociti totali</strong></td><td>&gt;11.000</td><td>1.5</td></tr>
+              <tr><td>8.501-11.000</td><td>0.5</td></tr>
+              <tr><td>&le;8.500</td><td>0</td></tr>
+              <tr><td rowspan="3"><strong>% Linfociti</strong></td><td>0-11.9%</td><td>2.5</td></tr>
+              <tr><td>12-19.9%</td><td>1.0</td></tr>
+              <tr><td>&ge;20%</td><td>0</td></tr>
+              <tr><td rowspan="5"><strong>Predizione clinica</strong></td><td>1-2 settimane</td><td>8.5</td></tr>
+              <tr><td>3-4 settimane</td><td>6.0</td></tr>
+              <tr><td>5-6 settimane</td><td>4.5</td></tr>
+              <tr><td>7-10 settimane</td><td>2.5</td></tr>
+              <tr><td>&gt;10 settimane</td><td>0</td></tr>
+            </tbody>
+          </table>
+        </div>
+        
+        <div class="interpretation-box">
+          <h5><i class="fas fa-info-circle me-2"></i>Interpretazione Prognostica</h5>
+          <ul>
+            <li><strong>Gruppo A (0-5.5 punti):</strong> Sopravvivenza &gt;30 giorni (probabilità &gt;70%)</li>
+            <li><strong>Gruppo B (5.6-11 punti):</strong> Sopravvivenza incerta (30-70%)</li>
+            <li><strong>Gruppo C (11.1-17.5 punti):</strong> Sopravvivenza &lt;30 giorni (probabilità &gt;70%)</li>
+            <li><strong>Punteggio totale:</strong> 0-17.5 punti</li>
+          </ul>
+        </div>
       </div>
-      <div class="text-center mt-3"><button class="btn btn-primary" onclick="window.print()">Stampa</button></div>
     </div>
   </div>
-</div>
+</section>
 
-<script>
-let ppiData={pps:null,oral:null,edema:null,dyspnea:null,delirium:null};
-let papData={dyspnea:null,anorexia:null,karnofsky:null,wbc:null,lymphocytes:null,prediction:null};
-function openProgModal(type){const m=document.getElementById('prog-modal-'+type);if(m){m.style.display='block';document.body.style.overflow='hidden';const dateInput=document.getElementById(type+'-date');if(dateInput&&!dateInput.value){dateInput.value=new Date().toISOString().split('T')[0];}}}
-function closeProgModal(type){const m=document.getElementById('prog-modal-'+type);if(m){m.style.display='none';document.body.style.overflow='auto';}}
-function showProgTab(scale,tab){const modal=document.getElementById('prog-modal-'+scale);modal.querySelectorAll('.tab-content').forEach(c=>c.classList.remove('active'));modal.querySelectorAll('.tab').forEach(t=>t.classList.remove('active'));modal.querySelector('#'+scale+'-'+tab).classList.add('active');event.target.classList.add('active');}
-function selectPPI(parameter,value){const radioGroup=event.target.closest('.radio-group');radioGroup.querySelectorAll('.radio-option').forEach(o=>{o.classList.remove('selected');o.querySelector('input').checked=false;});const option=event.target.closest('.radio-option');option.classList.add('selected');option.querySelector('input').checked=true;ppiData[parameter]=parseFloat(value);document.getElementById('ppi-'+parameter+'-item').classList.add('completed');updatePPIProgress();calculatePPI();}
-function selectPAP(parameter,value){const radioGroup=event.target.closest('.radio-group');radioGroup.querySelectorAll('.radio-option').forEach(o=>{o.classList.remove('selected');o.querySelector('input').checked=false;});const option=event.target.closest('.radio-option');option.classList.add('selected');option.querySelector('input').checked=true;papData[parameter]=parseFloat(value);document.getElementById('pap-'+parameter+'-item').classList.add('completed');updatePAPProgress();calculatePAP();}
-function updatePPIProgress(){const completed=Object.values(ppiData).filter(v=>v!==null).length;const total=Object.keys(ppiData).length;const perc=(completed/total)*100;document.getElementById('ppi-progress').style.width=perc+'%';document.getElementById('ppi-progress-text').textContent=`${completed}/${total}`;}
-function updatePAPProgress(){const completed=Object.values(papData).filter(v=>v!==null).length;const total=Object.keys(papData).length;const perc=(completed/total)*100;document.getElementById('pap-progress').style.width=perc+'%';document.getElementById('pap-progress-text').textContent=`${completed}/${total}`;}
-function calculatePPI(){const completed=Object.values(ppiData).filter(v=>v!==null).length;if(completed===Object.keys(ppiData).length){const total=Object.values(ppiData).reduce((s,v)=>s+v,0);let interp='',desc='';if(total<=4){interp='Buona prognosi';desc='Sopravvivenza >6 settimane (probabilità >70%)';}else{interp='Prognosi riservata';desc='Sopravvivenza ≤3 settimane (probabilità >80%)';}document.getElementById('ppi-score').textContent=total.toFixed(1);document.getElementById('ppi-interpretation').textContent=interp;document.getElementById('ppi-description').textContent=desc;document.getElementById('ppi-results').style.display='block';}else{document.getElementById('ppi-results').style.display='none';}}
-function calculatePAP(){const completed=Object.values(papData).filter(v=>v!==null).length;if(completed===Object.keys(papData).length){const total=Object.values(papData).reduce((s,v)=>s+v,0);let interp='',desc='',group='';if(total<=5.5){group='A';interp='Buona prognosi';desc='Sopravvivenza >30 giorni (probabilità >70%)';}else if(total<=11){group='B';interp='Prognosi intermedia';desc='Sopravvivenza incerta (30-70% probabilità)';}else{group='C';interp='Prognosi riservata';desc='Sopravvivenza <30 giorni (probabilità >70%)';}document.getElementById('pap-score').textContent=total.toFixed(1);document.getElementById('pap-interpretation').textContent=`Gruppo ${group} - ${interp}`;document.getElementById('pap-description').textContent=desc;document.getElementById('pap-results').style.display='block';}else{document.getElementById('pap-results').style.display='none';}}
-function resetForm(type){if(confirm('Sei sicuro di voler azzerare tutti i dati?')){if(type==='ppi'){ppiData={pps:null,oral:null,edema:null,dyspnea:null,delirium:null};document.getElementById('ppi-patient-name').value='';updatePPIProgress();document.getElementById('ppi-results').style.display='none';}else{papData={dyspnea:null,anorexia:null,karnofsky:null,wbc:null,lymphocytes:null,prediction:null};document.getElementById('pap-patient-name').value='';updatePAPProgress();document.getElementById('pap-results').style.display='none';}document.querySelectorAll(`#prog-modal-${type} .radio-option`).forEach(o=>{o.classList.remove('selected');o.querySelector('input').checked=false;});document.querySelectorAll(`#prog-modal-${type} .form-item`).forEach(i=>i.classList.remove('completed'));}}
-function generateReport(type){const patientName=document.getElementById(`${type}-patient-name`).value||'Paziente non specificato';const date=document.getElementById(`${type}-date`).value||new Date().toISOString().split('T')[0];let content='';if(type==='ppi'){const completed=Object.values(ppiData).filter(v=>v!==null).length;if(completed<Object.keys(ppiData).length){alert('Completa tutti i parametri prima di generare il report');return;}const total=Object.values(ppiData).reduce((s,v)=>s+v,0);content=`REPORT PPI - PALLIATIVE PERFORMANCE INDEX\n==========================================\n\nPaziente: ${patientName}\nData valutazione: ${new Date(date).toLocaleDateString('it-IT')}\n\nPARAMETRI VALUTATI:\n• Palliative Performance Scale: ${ppiData.pps} punti\n• Assunzione orale: ${ppiData.oral} punti\n• Edema: ${ppiData.edema} punti\n• Dispnea a riposo: ${ppiData.dyspnea} punti\n• Delirium: ${ppiData.delirium} punti\n\nPUNTEGGIO TOTALE: ${total.toFixed(1)} punti\n\nINTERPRETAZIONE:\n${total<=4?'Buona prognosi - Sopravvivenza >6 settimane (probabilità >70%)':'Prognosi riservata - Sopravvivenza ≤3 settimane (probabilità >80%)'}\n\nValutato da: [Nome del medico]\nFirma: ____________________\n`; } else {const completed=Object.values(papData).filter(v=>v!==null).length;if(completed<Object.keys(papData).length){alert('Completa tutti i parametri prima di generare il report');return;}const total=Object.values(papData).reduce((s,v)=>s+v,0);let group=total<=5.5?'A':total<=11?'B':'C';content=`REPORT PAP SCORE - PALLIATIVE PROGNOSTIC SCORE\n==============================================\n\nPaziente: ${patientName}\nData valutazione: ${new Date(date).toLocaleDateString('it-IT')}\n\nPARAMETRI VALUTATI:\n• Dispnea: ${papData.dyspnea} punti\n• Anoressia: ${papData.anorexia} punti\n• Karnofsky Performance Status: ${papData.karnofsky} punti\n• Leucociti totali: ${papData.wbc} punti\n• Percentuale Linfociti: ${papData.lymphocytes} punti\n• Predizione clinica: ${papData.prediction} punti\n\nPUNTEGGIO TOTALE: ${total.toFixed(1)} punti\nGRUPPO PROGNOSTICO: ${group}\n\nINTERPRETAZIONE:\n${group==='A'?'Buona prognosi - Sopravvivenza >30 giorni (probabilità >70%)':group==='B'?'Prognosi intermedia - Sopravvivenza incerta (30-70% probabilità)':'Prognosi riservata - Sopravvivenza <30 giorni (probabilità >70%)'}\n\nValutato da: [Nome del medico]\nFirma: ____________________\n`; }
-const blob=new Blob([content],{type:'text/plain;charset=utf-8'});const url=URL.createObjectURL(blob);const a=document.createElement('a');a.href=url;a.download=`Report_${type.toUpperCase()}_${patientName.replace(/\s+/g,'_')}_${date}.txt`;document.body.appendChild(a);a.click();document.body.removeChild(a);URL.revokeObjectURL(url);}
-window.onclick=function(e){if(e.target.classList.contains('prog-modal')){e.target.style.display='none';document.body.style.overflow='auto';}};
-document.addEventListener('keydown',function(e){if(e.key==='Escape'){document.querySelectorAll('.prog-modal').forEach(m=>m.style.display='none');document.body.style.overflow='auto';}});
-document.addEventListener('DOMContentLoaded',function(){const today=new Date().toISOString().split('T')[0];const ppiDate=document.getElementById('ppi-date');if(ppiDate)ppiDate.value=today;const papDate=document.getElementById('pap-date');if(papDate)papDate.value=today;});
-</script>
+<script src="js/prognosi.js"></script>
 
-<style>
-.prognosi-container{max-width:1200px;margin:0 auto;padding:2rem 1rem;}
-.prognosi-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:2rem;margin-top:2rem;}
-.prognosi-card{background:white;border-radius:12px;box-shadow:0 4px 20px rgba(0,0,0,0.08);padding:2rem;transition:all 0.3s ease;border:1px solid #e9ecef;cursor:pointer;}
-.prognosi-card:hover{transform:translateY(-5px);box-shadow:0 8px 30px rgba(0,0,0,0.15);border-color:#5cb85c;}
-.card-header{display:flex;align-items:center;margin-bottom:1.5rem;}
-.card-icon{width:50px;height:50px;border-radius:10px;display:flex;align-items:center;justify-content:center;font-size:1.5rem;color:white;margin-right:1rem;font-weight:bold;}
-.ppi .card-icon{background:linear-gradient(135deg,#e74c3c,#c0392b);} .pap .card-icon{background:linear-gradient(135deg,#9b59b6,#8e44ad);}
-.card-title{font-size:1.4rem;font-weight:600;color:#5cb85c;margin-bottom:0.3rem;}
-.card-subtitle{font-size:0.9rem;color:#6c757d;font-weight:500;}
-.card-description{color:#555;margin-bottom:1.5rem;font-size:0.95rem;}
-.prog-modal{display:none;position:fixed;z-index:1000;left:0;top:0;width:100%;height:100%;background-color:rgba(0,0,0,0.5);}
-.prog-modal-content{background-color:white;margin:2% auto;padding:2rem;border-radius:12px;width:95%;max-width:900px;max-height:90vh;overflow-y:auto;position:relative;}
-.prog-close{position:absolute;right:1rem;top:1rem;font-size:2rem;font-weight:bold;cursor:pointer;color:#aaa;}
-.prog-close:hover{color:#000;}
-.tabs{display:flex;margin-bottom:2rem;border-bottom:2px solid #e9ecef;}
-.tab{padding:1rem 2rem;cursor:pointer;border:none;background:none;font-size:1rem;color:#6c757d;border-bottom:2px solid transparent;transition:all 0.3s ease;}
-.tab.active{color:#5cb85c;border-bottom-color:#5cb85c;}
-.tab:hover{color:#5cb85c;}
-.tab-content{display:none;}
-.tab-content.active{display:block;}
-.patient-info{background:#f8f9fa;padding:1.5rem;border-radius:8px;margin-bottom:2rem;}
-.patient-info h4{color:#5cb85c;margin-bottom:1rem;}
-.patient-info input{width:100%;padding:0.5rem;border:1px solid #dee2e6;border-radius:4px;margin-bottom:1rem;}
-.form-group{margin-bottom:1.5rem;padding:1rem;background:#f8f9fa;border-radius:8px;}
-.form-group h4{color:#5cb85c;margin-bottom:1rem;}
-.form-item{margin-bottom:1.5rem;padding:1rem;background:white;border-radius:8px;border-left:4px solid #dee2e6;}
-.form-item.completed{border-left-color:#28a745;}
-.radio-group{display:flex;flex-wrap:wrap;gap:1rem;margin-top:0.5rem;}
-.radio-option{display:flex;align-items:center;cursor:pointer;padding:0.5rem 1rem;border:2px solid #dee2e6;border-radius:25px;transition:all 0.3s ease;min-width:150px;}
-.radio-option:hover{border-color:#5cb85c;background:#f0f7ff;}
-.radio-option.selected{border-color:#28a745;background:#d4edda;color:#155724;}
-.score-display{background:linear-gradient(135deg,#5cb85c,#449d44);color:white;padding:2rem;border-radius:12px;text-align:center;margin:2rem 0;}
-.score-number{font-size:3rem;font-weight:bold;margin-bottom:0.5rem;}
-.score-interpretation{font-size:1.2rem;margin-bottom:1rem;}
-.score-description{font-size:1rem;opacity:0.9;}
-.scale-table{width:100%;border-collapse:collapse;margin:1rem 0;font-size:0.9rem;}
-.scale-table th,.scale-table td{border:1px solid #dee2e6;padding:0.75rem;text-align:left;}
-.scale-table th{background-color:#f8f9fa;font-weight:600;color:#495057;}
-.scale-table tbody tr:nth-child(even){background-color:#f8f9fa;}
-.btn-success{background:#28a745;color:white;}
-.btn-success:hover{background:#218838;}
-.reset-btn{background:#dc3545;color:white;}
-.reset-btn:hover{background:#c82333;}
-.progress-bar{background:#e9ecef;border-radius:10px;height:8px;margin:1rem 0;}
-.progress-fill{background:linear-gradient(90deg,#28a745,#20c997);height:100%;border-radius:10px;transition:width 0.3s ease;}
-@media (max-width:768px){.prognosi-grid{grid-template-columns:1fr;}.prog-modal-content{width:98%;margin:1% auto;padding:1rem;}.tabs{flex-wrap:wrap;}.tab{padding:0.75rem 1rem;font-size:0.9rem;}.radio-group{flex-direction:column;}.radio-option{min-width:auto;}}
-</style>

--- a/gestione-sintomi/strumenti-prognosi.php
+++ b/gestione-sintomi/strumenti-prognosi.php
@@ -22,44 +22,62 @@
     <!-- Sezione Strumenti -->
     <div id="tools-section" class="content-section active">
       <div class="prognosi-grid">
-        <div class="prognosi-card ppi" onclick="openPPICompile()">
-          <div class="card-header">
-            <div class="card-icon">PPI</div>
-            <div>
-              <div class="card-title">PPI</div>
-              <div class="card-subtitle">Palliative Performance Index</div>
+        <div class="tool-card tool-card-compact h-100 ppi">
+          <div class="tool-header">
+            <div class="tool-icon-large ppi-icon">
+              <span class="tool-letters">PPI</span>
+            </div>
+            <div class="tool-info">
+              <h4>PPI</h4>
+              <div class="tool-subtitle">Palliative Performance Index</div>
             </div>
           </div>
-          <div class="card-description">
+
+          <div class="tool-description">
             Strumento prognostico per stimare la sopravvivenza nei pazienti in cure palliative, basato su 5 parametri clinici facilmente valutabili.
           </div>
-          <ul class="card-features">
-            <li>5 parametri di valutazione</li>
-            <li>Predizione sopravvivenza a 3 e 6 settimane</li>
-            <li>Calcolo automatico del punteggio</li>
-            <li>Validato internazionalmente</li>
-          </ul>
-          <div class="card-footer">Clicca per compilare la scala</div>
+
+          <div class="tool-features">
+            <span class="feature-badge">5 parametri clinici: PPS, Assunzione orale, Edema, Dispnea, Delirium</span>
+          </div>
+
+          <div class="tool-actions">
+            <button class="btn btn-primary btn-action" onclick="openPPICompile()">
+              <i class="fas fa-edit me-2"></i>Compila
+            </button>
+            <button class="btn btn-outline-primary btn-action" onclick="openPPIVisualize()">
+              <i class="fas fa-table me-2"></i>Visualizza
+            </button>
+          </div>
         </div>
 
-        <div class="prognosi-card pap" onclick="openPAPCompile()">
-          <div class="card-header">
-            <div class="card-icon">PaP</div>
-            <div>
-              <div class="card-title">PaP Score</div>
-              <div class="card-subtitle">Palliative Prognostic Score</div>
+        <div class="tool-card tool-card-compact h-100 pap">
+          <div class="tool-header">
+            <div class="tool-icon-large pap-icon">
+              <span class="tool-letters">PaP</span>
+            </div>
+            <div class="tool-info">
+              <h4>PaP Score</h4>
+              <div class="tool-subtitle">Palliative Prognostic Score</div>
             </div>
           </div>
-          <div class="card-description">
+
+          <div class="tool-description">
             Score prognostico multidimensionale che combina valutazione clinica e parametri laboratoristici per predire la sopravvivenza a 30 giorni.
           </div>
-          <ul class="card-features">
-            <li>6 parametri clinici e laboratoristici</li>
-            <li>3 gruppi di rischio prognostico</li>
-            <li>Predizione sopravvivenza a 30 giorni</li>
-            <li>Ampiamente utilizzato in letteratura</li>
-          </ul>
-          <div class="card-footer">Clicca per compilare la scala</div>
+
+          <div class="tool-features">
+            <span class="feature-badge">6 parametri: Dispnea, Anoressia, Karnofsky, Leucociti, Linfociti, Predizione clinica</span>
+          </div>
+
+          <div class="tool-actions">
+            <button class="btn btn-primary btn-action" onclick="openPAPCompile()">
+              <i class="fas fa-edit me-2"></i>Compila
+            </button>
+            <button class="btn btn-outline-primary btn-action" onclick="openPAPVisualize()">
+              <i class="fas fa-table me-2"></i>Visualizza
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -131,8 +149,8 @@
     <button class="btn btn-outline-success me-2" onclick="navigateToSection('strumenti-valutazione-home'); showCategories();">
       <i class="fas fa-arrow-left me-2"></i>Torna alle Categorie
     </button>
-    <button class="btn btn-outline-primary" onclick="navigateToSection('performance-home')">
-      <i class="fas fa-arrow-left me-2"></i>Torna a Performance
+    <button class="btn btn-outline-primary" onclick="navigateToSection('prognosi-home')">
+      <i class="fas fa-arrow-left me-2"></i>Torna a Prognosi
     </button>
   </div>
   <div class="ppi-container">
@@ -300,7 +318,7 @@
         </div>
         
         <div class="interpretation-box">
-          <h5><i class="fas fa-info-circle me-2"></i>Interpretazione Prognostica</h5>
+          <h5>Interpretazione Prognostica</h5>
           <ul>
             <li><strong>PPI ≤ 4:</strong> Sopravvivenza &gt;6 settimane (probabilità &gt;70%)</li>
             <li><strong>PPI &gt; 4:</strong> Sopravvivenza ≤3 settimane (probabilità &gt;80%)</li>
@@ -319,8 +337,8 @@
     <button class="btn btn-outline-success me-2" onclick="navigateToSection('strumenti-valutazione-home'); showCategories();">
       <i class="fas fa-arrow-left me-2"></i>Torna alle Categorie
     </button>
-    <button class="btn btn-outline-primary" onclick="navigateToSection('performance-home')">
-      <i class="fas fa-arrow-left me-2"></i>Torna a Performance
+    <button class="btn btn-outline-primary" onclick="navigateToSection('prognosi-home')">
+      <i class="fas fa-arrow-left me-2"></i>Torna a Prognosi
     </button>
   </div>
   <div class="pap-container">
@@ -514,7 +532,7 @@
         </div>
         
         <div class="interpretation-box">
-          <h5><i class="fas fa-info-circle me-2"></i>Interpretazione Prognostica</h5>
+          <h5>Interpretazione Prognostica</h5>
           <ul>
             <li><strong>Gruppo A (0-5.5 punti):</strong> Sopravvivenza &gt;30 giorni (probabilità &gt;70%)</li>
             <li><strong>Gruppo B (5.6-11 punti):</strong> Sopravvivenza incerta (30-70%)</li>

--- a/gestione-sintomi/strumenti-prognosi.php
+++ b/gestione-sintomi/strumenti-prognosi.php
@@ -22,66 +22,44 @@
     <!-- Sezione Strumenti -->
     <div id="tools-section" class="content-section active">
       <div class="prognosi-grid">
-        <div class="tool-card tool-card-compact h-100">
-          <div class="tool-header">
-            <div class="tool-icon-large ppi-icon">
-              <span class="tool-letters">PPI</span>
-            </div>
-            <div class="tool-info">
-              <h4>PPI</h4>
-              <div class="tool-subtitle">Palliative Performance Index</div>
+        <div class="prognosi-card ppi" onclick="openPPICompile()">
+          <div class="card-header">
+            <div class="card-icon">PPI</div>
+            <div>
+              <div class="card-title">PPI</div>
+              <div class="card-subtitle">Palliative Performance Index</div>
             </div>
           </div>
-          
-          <div class="tool-description">
+          <div class="card-description">
             Strumento prognostico per stimare la sopravvivenza nei pazienti in cure palliative, basato su 5 parametri clinici facilmente valutabili.
           </div>
-          
-          <div class="tool-features">
-            <span class="feature-badge">5 parametri</span>
-            <span class="feature-badge">Predizione 3-6 settimane</span>
-            <span class="feature-badge">Validato</span>
-          </div>
-          
-          <div class="tool-actions">
-            <button class="btn btn-primary btn-action" onclick="openPPICompile()">
-              <i class="fas fa-edit me-2"></i>Compila
-            </button>
-            <button class="btn btn-outline-primary btn-action" onclick="openPPIVisualize()">
-              <i class="fas fa-table me-2"></i>Visualizza
-            </button>
-          </div>
+          <ul class="card-features">
+            <li>5 parametri di valutazione</li>
+            <li>Predizione sopravvivenza a 3 e 6 settimane</li>
+            <li>Calcolo automatico del punteggio</li>
+            <li>Validato internazionalmente</li>
+          </ul>
+          <div class="card-footer">Clicca per compilare la scala</div>
         </div>
 
-        <div class="tool-card tool-card-compact h-100">
-          <div class="tool-header">
-            <div class="tool-icon-large pap-icon">
-              <span class="tool-letters">PaP</span>
-            </div>
-            <div class="tool-info">
-              <h4>PaP Score</h4>
-              <div class="tool-subtitle">Palliative Prognostic Score</div>
+        <div class="prognosi-card pap" onclick="openPAPCompile()">
+          <div class="card-header">
+            <div class="card-icon">PaP</div>
+            <div>
+              <div class="card-title">PaP Score</div>
+              <div class="card-subtitle">Palliative Prognostic Score</div>
             </div>
           </div>
-          
-          <div class="tool-description">
+          <div class="card-description">
             Score prognostico multidimensionale che combina valutazione clinica e parametri laboratoristici per predire la sopravvivenza a 30 giorni.
           </div>
-          
-          <div class="tool-features">
-            <span class="feature-badge">6 parametri</span>
-            <span class="feature-badge">3 gruppi rischio</span>
-            <span class="feature-badge">30 giorni</span>
-          </div>
-          
-          <div class="tool-actions">
-            <button class="btn btn-primary btn-action" onclick="openPAPCompile()">
-              <i class="fas fa-edit me-2"></i>Compila
-            </button>
-            <button class="btn btn-outline-primary btn-action" onclick="openPAPVisualize()">
-              <i class="fas fa-table me-2"></i>Visualizza
-            </button>
-          </div>
+          <ul class="card-features">
+            <li>6 parametri clinici e laboratoristici</li>
+            <li>3 gruppi di rischio prognostico</li>
+            <li>Predizione sopravvivenza a 30 giorni</li>
+            <li>Ampiamente utilizzato in letteratura</li>
+          </ul>
+          <div class="card-footer">Clicca per compilare la scala</div>
         </div>
       </div>
     </div>
@@ -149,6 +127,14 @@
 
 <!-- Sezione PPI -->
 <section id="ppi-home" class="p-4" style="display:none;">
+  <div class="mb-3">
+    <button class="btn btn-outline-success me-2" onclick="navigateToSection('strumenti-valutazione-home'); showCategories();">
+      <i class="fas fa-arrow-left me-2"></i>Torna alle Categorie
+    </button>
+    <button class="btn btn-outline-primary" onclick="navigateToSection('performance-home')">
+      <i class="fas fa-arrow-left me-2"></i>Torna a Performance
+    </button>
+  </div>
   <div class="ppi-container">
     <div class="ppi-header">
       <h1><i class="fas fa-hourglass-half me-2"></i>PPI - Palliative Performance Index</h1>
@@ -281,6 +267,11 @@
     <!-- Tab Visualizza -->
     <div id="ppi-visualize-section" class="content-section">
       <div class="scale-reference">
+        <div class="text-end mb-3">
+          <button class="btn btn-outline-primary no-print" onclick="printPPIForm()">
+            <i class="fas fa-print me-2"></i>Stampa
+          </button>
+        </div>
         <h4>Palliative Performance Index (PPI) - Scala Completa</h4>
         <div class="table-responsive">
           <table class="scale-table">
@@ -324,6 +315,14 @@
 
 <!-- Sezione PaP Score -->
 <section id="pap-home" class="p-4" style="display:none;">
+  <div class="mb-3">
+    <button class="btn btn-outline-success me-2" onclick="navigateToSection('strumenti-valutazione-home'); showCategories();">
+      <i class="fas fa-arrow-left me-2"></i>Torna alle Categorie
+    </button>
+    <button class="btn btn-outline-primary" onclick="navigateToSection('performance-home')">
+      <i class="fas fa-arrow-left me-2"></i>Torna a Performance
+    </button>
+  </div>
   <div class="pap-container">
     <div class="pap-header">
       <h1><i class="fas fa-chart-line me-2"></i>PaP Score - Palliative Prognostic Score</h1>
@@ -477,6 +476,11 @@
     <!-- Tab Visualizza -->
     <div id="pap-visualize-section" class="content-section">
       <div class="scale-reference">
+        <div class="text-end mb-3">
+          <button class="btn btn-outline-primary no-print" onclick="printPAPForm()">
+            <i class="fas fa-print me-2"></i>Stampa
+          </button>
+        </div>
         <h4>Palliative Prognostic Score (PaP) - Scala Completa</h4>
         <div class="table-responsive">
           <table class="scale-table">

--- a/gestione-sintomi/strumenti-prognosi.php
+++ b/gestione-sintomi/strumenti-prognosi.php
@@ -5,9 +5,15 @@
 
 <section id="prognosi-home" class="p-4" style="display:none;">
   <div class="prognosi-container">
-    <div class="prognosi-header">
-      <h1><i class="fas fa-hourglass-half me-2"></i>Strumenti di Prognosi</h1>
-      <p class="text-muted">Scale prognostiche validate per la valutazione dell'aspettativa di vita in cure palliative</p>
+    <div class="mb-3">
+      <button class="btn btn-outline-success" onclick="navigateToSection('strumenti-valutazione-home')">
+        <i class="fas fa-arrow-left me-2"></i>Torna alle Categorie
+      </button>
+    </div>
+
+    <div class="category-detail-header">
+      <h3><i class="fas fa-hourglass-half me-2"></i>Strumenti di Prognosi</h3>
+      <p class="mb-0">Scale prognostiche validate per la valutazione dell'aspettativa di vita in cure palliative</p>
     </div>
 
     <div class="mode-selector mb-4">

--- a/gestione-sintomi/strumenti-prognosi.php
+++ b/gestione-sintomi/strumenti-prognosi.php
@@ -165,7 +165,7 @@
     </div>
 
     <!-- Tab Compila -->
-    <div id="compile-section" class="content-section active">
+    <div id="ppi-compile-section" class="content-section active">
       <div class="patient-info-card">
         <h4><i class="fas fa-user me-2"></i>Dati Paziente</h4>
         <div class="row">
@@ -279,7 +279,7 @@
     </div>
 
     <!-- Tab Visualizza -->
-    <div id="visualize-section" class="content-section">
+    <div id="ppi-visualize-section" class="content-section">
       <div class="scale-reference">
         <h4>Palliative Performance Index (PPI) - Scala Completa</h4>
         <div class="table-responsive">
@@ -340,7 +340,7 @@
     </div>
 
     <!-- Tab Compila -->
-    <div id="compile-section" class="content-section active">
+    <div id="pap-compile-section" class="content-section active">
       <div class="patient-info-card">
         <h4><i class="fas fa-user me-2"></i>Dati Paziente</h4>
         <div class="row">
@@ -475,7 +475,7 @@
     </div>
 
     <!-- Tab Visualizza -->
-    <div id="visualize-section" class="content-section">
+    <div id="pap-visualize-section" class="content-section">
       <div class="scale-reference">
         <h4>Palliative Prognostic Score (PaP) - Scala Completa</h4>
         <div class="table-responsive">


### PR DESCRIPTION
## Summary
- Introduce sezione "Strumenti di Prognosi" con scale PPI e PaP complete di compilazione, visualizzazione e riferimenti.
- Aggiorna la sidebar e la navigazione JS per accedere rapidamente a Prognosi, PPI e PaP.
- Estende gli strumenti di valutazione con nuova categoria Prognosi e relative funzioni di apertura.

## Testing
- `php -l gestione-sintomi/index.php`
- `php -l gestione-sintomi/strumenti-prognosi.php`


------
https://chatgpt.com/codex/tasks/task_e_68983e6af7808328ab4713fda051c8a2