### PR TITLE
Allinea colori bottoni in Identificazione

### DIFF
--- a/gestione-sintomi/strumenti-necpal31.php
+++ b/gestione-sintomi/strumenti-necpal31.php
@@ -400,10 +400,10 @@
         }
     </style>
     <div class="mb-3">
-        <button class="btn btn-outline-success me-2" onclick="navigateToSection('identificazione-home')">
+        <button class="btn btn-outline-primary me-2" onclick="navigateToSection('identificazione-home')">
             <i class="fas fa-arrow-left me-2"></i>Torna a Identificazione
         </button>
-        <button class="btn btn-outline-primary" onclick="navigateToSection('strumenti-valutazione-home'); showCategories();">
+        <button class="btn btn-outline-success" onclick="navigateToSection('strumenti-valutazione-home'); showCategories();">
             <i class="fas fa-arrow-left me-2"></i>Torna alle Categorie
         </button>
     </div>

--- a/gestione-sintomi/strumenti-necpal40.php
+++ b/gestione-sintomi/strumenti-necpal40.php
@@ -314,10 +314,10 @@
         }
     </style>
     <div class="mb-3">
-        <button class="btn btn-outline-success me-2" onclick="navigateToSection('identificazione-home')">
+        <button class="btn btn-outline-primary me-2" onclick="navigateToSection('identificazione-home')">
             <i class="fas fa-arrow-left me-2"></i>Torna a Identificazione
         </button>
-        <button class="btn btn-outline-primary" onclick="navigateToSection('strumenti-valutazione-home'); showCategories();">
+        <button class="btn btn-outline-success" onclick="navigateToSection('strumenti-valutazione-home'); showCategories();">
             <i class="fas fa-arrow-left me-2"></i>Torna alle Categorie
         </button>
     </div>

--- a/gestione-sintomi/strumenti-spict.php
+++ b/gestione-sintomi/strumenti-spict.php
@@ -61,8 +61,8 @@
         @media(max-width:768px){.pathology-grid{grid-template-columns:1fr;} .mode-selector{flex-direction:column;} .summary-stats{grid-template-columns:1fr;}}
     </style>
     <div class="mb-3">
-        <button class="btn btn-outline-success me-2" onclick="navigateToSection('identificazione-home')"><i class="fas fa-arrow-left me-2"></i>Torna a Identificazione</button>
-        <button class="btn btn-outline-primary" onclick="navigateToSection('strumenti-valutazione-home')"><i class="fas fa-arrow-left me-2"></i>Torna alle Categorie</button>
+        <button class="btn btn-outline-primary me-2" onclick="navigateToSection('identificazione-home')"><i class="fas fa-arrow-left me-2"></i>Torna a Identificazione</button>
+        <button class="btn btn-outline-success" onclick="navigateToSection('strumenti-valutazione-home')"><i class="fas fa-arrow-left me-2"></i>Torna alle Categorie</button>
     </div>
     <div class="spict-container">
         <div class="spict-header">


### PR DESCRIPTION
## Summary
- Inverti i colori dei pulsanti di ritorno nelle pagine degli strumenti di identificazione per uniformarli alle altre sezioni

## Testing
- `php -l gestione-sintomi/strumenti-necpal31.php`
- `php -l gestione-sintomi/strumenti-necpal40.php`
- `php -l gestione-sintomi/strumenti-spict.php`


------
https://chatgpt.com/codex/tasks/task_e_689b848044548328bd7b05518d5696b1