### PR TITLE
Aggiunte schede di riferimento 4AT e CAM

### DIFF
--- a/gestione-sintomi/css/delirium.css
+++ b/gestione-sintomi/css/delirium.css
@@ -1,0 +1,330 @@
+:root {
+  --delirium-primary: #17a2b8;
+  --delirium-secondary: #138496;
+  --delirium-light: #d1ecf1;
+  --success-color: #28a745;
+  --warning-color: #ffc107;
+  --danger-color: #dc3545;
+}
+
+body {
+  background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  min-height: 100vh;
+}
+
+.container-fluid {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.delirium-header {
+  background: linear-gradient(135deg, var(--delirium-primary), var(--delirium-secondary));
+  color: #fff;
+  padding: 3rem 2rem;
+  border-radius: 20px;
+  text-align: center;
+  box-shadow: 0 10px 40px rgba(23,162,184,0.3);
+  margin-bottom: 3rem;
+}
+
+.delirium-header h1 {
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+
+.tools-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(500px,1fr));
+  gap: 2rem;
+}
+
+.tool-card {
+  background: #fff;
+  border-radius: 20px;
+  border: 3px solid var(--delirium-primary);
+  padding: 2.5rem;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.1);
+  transition: all 0.3s ease;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.tool-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 15px 50px rgba(23,162,184,0.2);
+}
+
+.tool-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 2rem;
+}
+
+.tool-icon-large {
+  width: 80px;
+  height: 80px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, var(--delirium-primary), var(--delirium-secondary));
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  font-weight: 700;
+  margin-right: 1.5rem;
+  box-shadow: 0 4px 20px rgba(23,162,184,0.3);
+}
+
+.tool-info h4 {
+  font-size: 2.2rem;
+  font-weight: 700;
+  color: var(--delirium-primary);
+  margin-bottom: 0.5rem;
+}
+
+.tool-subtitle {
+  font-size: 1.1rem;
+  color: #6c757d;
+  font-weight: 500;
+}
+
+.tool-description {
+  color: #495057;
+  font-size: 1.1rem;
+  line-height: 1.6;
+  margin-bottom: 2rem;
+  flex-grow: 1;
+}
+
+.tool-features {
+  background: rgba(23,162,184,0.1);
+  border-radius: 12px;
+  padding: 1rem 1.5rem;
+  border: 1px solid rgba(23,162,184,0.2);
+  margin-bottom: 2rem;
+}
+
+.feature-text {
+  color: var(--delirium-primary);
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.tool-actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.btn-action {
+  flex: 1;
+  min-width: 140px;
+  padding: 1rem 1.5rem;
+  font-weight: 600;
+  border-radius: 12px;
+  transition: all 0.3s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, var(--delirium-primary), var(--delirium-secondary));
+  border: none;
+  color: #fff;
+}
+
+.btn-primary:hover {
+  background: linear-gradient(135deg, var(--delirium-secondary), #0d7377);
+  transform: translateY(-2px);
+  box-shadow: 0 5px 15px rgba(23,162,184,0.4);
+}
+
+.btn-outline-primary {
+  border: 2px solid var(--delirium-primary);
+  color: var(--delirium-primary);
+  background: #fff;
+}
+
+.btn-outline-primary:hover {
+  background: var(--delirium-primary);
+  color: #fff;
+  transform: translateY(-2px);
+  box-shadow: 0 5px 15px rgba(23,162,184,0.3);
+}
+
+.assessment-section {
+  display: none;
+  background: #fff;
+  border-radius: 20px;
+  padding: 3rem;
+  box-shadow: 0 10px 40px rgba(0,0,0,0.1);
+  margin-bottom: 2rem;
+}
+
+.assessment-section.active {
+  display: block;
+  animation: fadeInUp 0.5s ease;
+}
+
+@keyframes fadeInUp {
+  from {opacity:0; transform: translateY(30px);}
+  to {opacity:1; transform: translateY(0);}
+}
+
+.delirium-section .assessment-header h2 {
+  color: var(--delirium-primary);
+}
+
+.delirium-section .mode-selector {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 1.5rem;
+  gap: 0.5rem;
+}
+
+.delirium-section .mode-btn {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 20px;
+  background: #f8f9fa;
+  cursor: pointer;
+  color: #6c757d;
+}
+
+.delirium-section .mode-btn.active {
+  background: var(--delirium-primary);
+  color: #fff;
+}
+
+.delirium-section .patient-info {
+  background: #f8f9fa;
+  padding: 1rem;
+  border-radius: 8px;
+  margin-bottom: 1.5rem;
+}
+
+.delirium-section .question-item {
+  background: #fff;
+  border: 1px solid #e9ecef;
+  border-radius: 10px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+.delirium-section .question-item.completed {
+  border-color: var(--success-color);
+}
+
+.delirium-section .question-title {
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--delirium-primary);
+}
+
+.delirium-section .question-number {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: var(--delirium-primary);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+}
+
+.delirium-section .question-description {
+  font-size: 0.9rem;
+  color: #6c757d;
+  margin-bottom: 0.5rem;
+}
+
+.delirium-section .radio-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.delirium-section .radio-option {
+  border: 1px solid #e9ecef;
+  border-radius: 8px;
+  padding: 0.5rem;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+.delirium-section .radio-option.selected {
+  border-color: var(--delirium-primary);
+  background: var(--delirium-light);
+}
+
+.delirium-section .radio-label {
+  flex-grow: 1;
+}
+
+.delirium-section .radio-score {
+  margin-left: auto;
+  font-weight: bold;
+}
+
+.delirium-section .progress-container {
+  margin: 1rem 0;
+}
+
+.delirium-section .results-container {
+  text-align: center;
+  background: #f8f9fa;
+  border: 1px solid var(--delirium-primary);
+  border-radius: 10px;
+  padding: 1.5rem;
+  margin-top: 1rem;
+}
+
+.delirium-section .score-display {
+  font-size: 3rem;
+  font-weight: 700;
+  color: var(--delirium-primary);
+}
+
+.delirium-section .score-interpretation {
+  font-size: 1.3rem;
+  font-weight: 600;
+}
+
+.delirium-section .scale-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.delirium-section .scale-table th {
+  background: var(--delirium-primary);
+  color: #fff;
+  padding: 0.5rem;
+}
+
+.delirium-section .scale-table td {
+  border: 1px solid #dee2e6;
+  padding: 0.5rem;
+}
+
+.delirium-section .action-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+}
+
+.hidden {
+  display: none !important;
+}

--- a/gestione-sintomi/delirium.php
+++ b/gestione-sintomi/delirium.php
@@ -1,0 +1,355 @@
+<?php
+?>
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Scale di Valutazione Delirium - 4AT e CAM</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.1/css/all.min.css" rel="stylesheet">
+    <link href="css/delirium.css" rel="stylesheet">
+</head>
+<body>
+    <div class="container-fluid">
+        <!-- Main View -->
+        <div id="main-view">
+            <div class="delirium-header">
+                <h1><i class="fas fa-brain me-3"></i>Scale di Valutazione Delirium</h1>
+                <p>Strumenti clinici per la diagnosi e il monitoraggio del delirium in ambito sanitario</p>
+            </div>
+            <div class="tools-grid">
+                <div class="tool-card">
+                    <div class="tool-header">
+                        <div class="tool-icon-large"><span class="tool-letters">4AT</span></div>
+                        <div class="tool-info">
+                            <h4>4AT</h4>
+                            <div class="tool-subtitle">4 'A's Test</div>
+                        </div>
+                    </div>
+                    <div class="tool-description">
+                        Test di screening rapido per il delirium, validato in diversi setting clinici. Valuta 4 domini cognitivi: allerta, attenzione, cognizione acuta e pensiero disorganizzato.
+                    </div>
+                    <div class="tool-features">
+                        <div class="feature-text">4 parametri: Allerta, Attenzione, Pensiero disorganizzato, Fluttuazione acuta - Punteggio 0-12 - Screening rapido</div>
+                    </div>
+                    <div class="tool-actions">
+                        <button class="btn btn-primary btn-action" onclick="show4ATAssessment()"><i class="fas fa-edit me-2"></i>Compila</button>
+                        <a href="strumenti-4at.php" class="btn btn-outline-primary btn-action"><i class="fas fa-eye me-2"></i>Visualizza</a>
+                    </div>
+                </div>
+                <div class="tool-card">
+                    <div class="tool-header">
+                        <div class="tool-icon-large"><span class="tool-letters">CAM</span></div>
+                        <div class="tool-info">
+                            <h4>CAM</h4>
+                            <div class="tool-subtitle">Confusion Assessment Method</div>
+                        </div>
+                    </div>
+                    <div class="tool-description">
+                        Algoritmo diagnostico gold standard per il delirium. Valuta 4 caratteristiche principali con alta sensibilità e specificità per la diagnosi di delirium.
+                    </div>
+                    <div class="tool-features">
+                        <div class="feature-text">4 caratteristiche: Esordio acuto, Attenzione, Pensiero disorganizzato, Livello di coscienza - Algoritmo diagnostico - Gold standard</div>
+                    </div>
+                    <div class="tool-actions">
+                        <button class="btn btn-primary btn-action" onclick="showCAMAssessment()"><i class="fas fa-edit me-2"></i>Compila</button>
+                        <a href="strumenti-cam.php" class="btn btn-outline-primary btn-action"><i class="fas fa-eye me-2"></i>Visualizza</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- 4AT Assessment Section -->
+        <div id="4at-assessment" class="assessment-section delirium-section">
+            <div class="mb-3">
+                <a href="index.php" class="btn btn-success me-2"><i class="fas fa-arrow-left me-2"></i>Torna alle Categorie</a>
+                <button class="btn btn-outline-secondary" style="border-color:#6f42c1;color:#6f42c1;" onclick="showMainView()"><i class="fas fa-arrow-left me-2"></i>Torna a Delirium</button>
+            </div>
+            <div class="assessment-header">
+                <h2>4AT - 4 'A's Test</h2>
+                <p>Screening rapido per delirium</p>
+            </div>
+            <div class="mode-selector">
+                <button class="mode-btn active" onclick="switch4ATMode('compile')">📝 Compila</button>
+                <a href="strumenti-4at.php" class="mode-btn">📊 Scala di Riferimento</a>
+            </div>
+            <div id="4at-compile" class="content-section">
+                <div class="patient-info">
+                    <h4><i class="fas fa-user me-2"></i>Dati Paziente</h4>
+                    <div class="row g-3">
+                        <div class="col-md-6">
+                            <label class="form-label">Nome Paziente</label>
+                            <input type="text" class="form-control" id="4at-patient-name" placeholder="Nome e cognome">
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label">Data di Nascita</label>
+                            <input type="date" class="form-control" id="4at-patient-birth">
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label">Data Valutazione</label>
+                            <input type="date" class="form-control" id="4at-date">
+                        </div>
+                    </div>
+                </div>
+                <div class="progress-container">
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                        <span><strong>Progresso Compilazione</strong></span>
+                        <span id="4at-progress-text">0/4 completati</span>
+                    </div>
+                    <div class="progress">
+                        <div class="progress-bar" id="4at-progress-bar" role="progressbar" style="width:0%"></div>
+                    </div>
+                </div>
+                <div class="question-item" id="4at-q1">
+                    <div class="question-title">
+                        <div class="question-number">1</div>
+                        <div>Allerta (Alertness)</div>
+                    </div>
+                    <div class="question-description">
+                        Valutare il livello di allerta del paziente. Se addormentato, cercare di svegliarlo normalmente.
+                    </div>
+                    <div class="radio-options">
+                        <label class="radio-option" onclick="select4ATAnswer(1,0,this)">
+                            <input type="radio" name="4at-q1" value="0">
+                            <span class="radio-label">Normale (completamente allerta o facile da svegliare)</span>
+                            <span class="radio-score">0</span>
+                        </label>
+                        <label class="radio-option" onclick="select4ATAnswer(1,4,this)">
+                            <input type="radio" name="4at-q1" value="4">
+                            <span class="radio-label">Alterata (chiaramente anomala, soporoso/stupor)</span>
+                            <span class="radio-score">4</span>
+                        </label>
+                    </div>
+                </div>
+                <div class="question-item" id="4at-q2">
+                    <div class="question-title">
+                        <div class="question-number">2</div>
+                        <div>Test di Attenzione</div>
+                    </div>
+                    <div class="question-description">
+                        Dire al paziente: "Ora dirò alcune lettere. Ogni volta che sente la lettera 'A', batta le mani".<br>Sequenza: SAVEAHAART.
+                    </div>
+                    <div class="radio-options">
+                        <label class="radio-option" onclick="select4ATAnswer(2,0,this)">
+                            <input type="radio" name="4at-q2" value="0">
+                            <span class="radio-label">Nessun errore</span>
+                            <span class="radio-score">0</span>
+                        </label>
+                        <label class="radio-option" onclick="select4ATAnswer(2,1,this)">
+                            <input type="radio" name="4at-q2" value="1">
+                            <span class="radio-label">1 errore</span>
+                            <span class="radio-score">1</span>
+                        </label>
+                        <label class="radio-option" onclick="select4ATAnswer(2,2,this)">
+                            <input type="radio" name="4at-q2" value="2">
+                            <span class="radio-label">2 o più errori / non testabile</span>
+                            <span class="radio-score">2</span>
+                        </label>
+                    </div>
+                </div>
+                <div class="question-item" id="4at-q3">
+                    <div class="question-title">
+                        <div class="question-number">3</div>
+                        <div>Attenzione (test alternativo)</div>
+                    </div>
+                    <div class="question-description">
+                        Se il paziente non riesce a completare il test precedente, chiedere: "Può dirmi tutti i mesi dell'anno all'indietro, partendo da dicembre?"
+                    </div>
+                    <div class="radio-options">
+                        <label class="radio-option" onclick="select4ATAnswer(3,0,this)">
+                            <input type="radio" name="4at-q3" value="0">
+                            <span class="radio-label">7 o più mesi corretti</span>
+                            <span class="radio-score">0</span>
+                        </label>
+                        <label class="radio-option" onclick="select4ATAnswer(3,1,this)">
+                            <input type="radio" name="4at-q3" value="1">
+                            <span class="radio-label">Meno di 7 mesi / si rifiuta di iniziare</span>
+                            <span class="radio-score">1</span>
+                        </label>
+                        <label class="radio-option" onclick="select4ATAnswer(3,2,this)">
+                            <input type="radio" name="4at-q3" value="2">
+                            <span class="radio-label">Non testabile</span>
+                            <span class="radio-score">2</span>
+                        </label>
+                    </div>
+                </div>
+                <div class="question-item" id="4at-q4">
+                    <div class="question-title">
+                        <div class="question-number">4</div>
+                        <div>Cambiamento Acuto o Corso Fluttuante</div>
+                    </div>
+                    <div class="question-description">
+                        C'è evidenza di cambiamento significativo nello stato mentale rispetto alla baseline? Il comportamento varia durante il giorno?
+                    </div>
+                    <div class="radio-options">
+                        <label class="radio-option" onclick="select4ATAnswer(4,0,this)">
+                            <input type="radio" name="4at-q4" value="0">
+                            <span class="radio-label">No</span>
+                            <span class="radio-score">0</span>
+                        </label>
+                        <label class="radio-option" onclick="select4ATAnswer(4,4,this)">
+                            <input type="radio" name="4at-q4" value="4">
+                            <span class="radio-label">Sì</span>
+                            <span class="radio-score">4</span>
+                        </label>
+                    </div>
+                </div>
+                <div id="4at-results" class="results-container hidden">
+                    <div class="score-display" id="4at-score">0</div>
+                    <div class="score-interpretation" id="4at-interpretation"></div>
+                    <div class="score-description" id="4at-description"></div>
+                    <div class="action-buttons">
+                        <button class="btn btn-warning" onclick="print4AT()"><i class="fas fa-print me-2"></i>Stampa</button>
+                        <button class="btn btn-secondary" onclick="reset4AT()"><i class="fas fa-redo me-2"></i>Reset</button>
+                    </div>
+                </div>
+            </div>
+            <div id="4at-reference" class="content-section hidden">
+                <div class="alert alert-info">Consulta la scala di riferimento completa nella scheda <em>Visualizza</em>.</div>
+            </div>
+        </div>
+
+        <!-- CAM Assessment Section -->
+        <div id="cam-assessment" class="assessment-section delirium-section">
+            <div class="mb-3">
+                <a href="index.php" class="btn btn-success me-2"><i class="fas fa-arrow-left me-2"></i>Torna alle Categorie</a>
+                <button class="btn btn-outline-secondary" style="border-color:#6f42c1;color:#6f42c1;" onclick="showMainView()"><i class="fas fa-arrow-left me-2"></i>Torna a Delirium</button>
+            </div>
+            <div class="assessment-header">
+                <h2>CAM - Confusion Assessment Method</h2>
+                <p>Algoritmo diagnostico per delirium</p>
+            </div>
+            <div class="mode-selector">
+                <button class="mode-btn active" onclick="switchCAMMode('compile')">📝 Compila</button>
+                <a href="strumenti-cam.php" class="mode-btn">📊 Algoritmo Diagnostico</a>
+            </div>
+            <div id="cam-compile" class="content-section">
+                <div class="patient-info">
+                    <h4><i class="fas fa-user me-2"></i>Dati Paziente</h4>
+                    <div class="row g-3">
+                        <div class="col-md-6">
+                            <label class="form-label">Nome Paziente</label>
+                            <input type="text" class="form-control" id="cam-patient-name" placeholder="Nome e cognome">
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label">Data di Nascita</label>
+                            <input type="date" class="form-control" id="cam-patient-birth">
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label">Data Valutazione</label>
+                            <input type="date" class="form-control" id="cam-date">
+                        </div>
+                    </div>
+                </div>
+                <div class="progress-container">
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                        <span><strong>Progresso Compilazione</strong></span>
+                        <span id="cam-progress-text">0/4 completati</span>
+                    </div>
+                    <div class="progress">
+                        <div class="progress-bar" id="cam-progress-bar" role="progressbar" style="width:0%"></div>
+                    </div>
+                </div>
+                <div class="question-item" id="cam-f1">
+                    <div class="question-title">
+                        <div class="question-number">1</div>
+                        <div>Esordio Acuto e Corso Fluttuante</div>
+                    </div>
+                    <div class="question-description">
+                        C'è evidenza di un cambiamento acuto nello stato mentale rispetto alla baseline? Il comportamento varia durante il giorno?
+                    </div>
+                    <div class="radio-options">
+                        <label class="radio-option" onclick="selectCAMAnswer(1,false,this)">
+                            <input type="radio" name="cam-f1" value="false">
+                            <span class="radio-label">Assente</span>
+                            <span class="radio-score">No</span>
+                        </label>
+                        <label class="radio-option" onclick="selectCAMAnswer(1,true,this)">
+                            <input type="radio" name="cam-f1" value="true">
+                            <span class="radio-label">Presente</span>
+                            <span class="radio-score">Sì</span>
+                        </label>
+                    </div>
+                </div>
+                <div class="question-item" id="cam-f2">
+                    <div class="question-title">
+                        <div class="question-number">2</div>
+                        <div>Disattenzione</div>
+                    </div>
+                    <div class="question-description">
+                        Il paziente ha difficoltà a focalizzare l'attenzione?
+                    </div>
+                    <div class="radio-options">
+                        <label class="radio-option" onclick="selectCAMAnswer(2,false,this)">
+                            <input type="radio" name="cam-f2" value="false">
+                            <span class="radio-label">Assente</span>
+                            <span class="radio-score">No</span>
+                        </label>
+                        <label class="radio-option" onclick="selectCAMAnswer(2,true,this)">
+                            <input type="radio" name="cam-f2" value="true">
+                            <span class="radio-label">Presente</span>
+                            <span class="radio-score">Sì</span>
+                        </label>
+                    </div>
+                </div>
+                <div class="question-item" id="cam-f3">
+                    <div class="question-title">
+                        <div class="question-number">3</div>
+                        <div>Pensiero Disorganizzato</div>
+                    </div>
+                    <div class="question-description">
+                        Il pensiero del paziente è disorganizzato o incoerente?
+                    </div>
+                    <div class="radio-options">
+                        <label class="radio-option" onclick="selectCAMAnswer(3,false,this)">
+                            <input type="radio" name="cam-f3" value="false">
+                            <span class="radio-label">Assente</span>
+                            <span class="radio-score">No</span>
+                        </label>
+                        <label class="radio-option" onclick="selectCAMAnswer(3,true,this)">
+                            <input type="radio" name="cam-f3" value="true">
+                            <span class="radio-label">Presente</span>
+                            <span class="radio-score">Sì</span>
+                        </label>
+                    </div>
+                </div>
+                <div class="question-item" id="cam-f4">
+                    <div class="question-title">
+                        <div class="question-number">4</div>
+                        <div>Livello di Coscienza Alterato</div>
+                    </div>
+                    <div class="question-description">
+                        Nel complesso, come valuta il livello di coscienza del paziente?
+                    </div>
+                    <div class="radio-options">
+                        <label class="radio-option" onclick="selectCAMAnswer(4,false,this)">
+                            <input type="radio" name="cam-f4" value="false">
+                            <span class="radio-label">Allerta (normale)</span>
+                            <span class="radio-score">No</span>
+                        </label>
+                        <label class="radio-option" onclick="selectCAMAnswer(4,true,this)">
+                            <input type="radio" name="cam-f4" value="true">
+                            <span class="radio-label">Vigile, letargico o stupor</span>
+                            <span class="radio-score">Sì</span>
+                        </label>
+                    </div>
+                </div>
+                <div id="cam-results" class="results-container hidden">
+                    <div class="score-display" id="cam-diagnosis"></div>
+                    <div class="score-interpretation" id="cam-interpretation"></div>
+                    <div class="score-description" id="cam-description"></div>
+                    <div class="action-buttons">
+                        <button class="btn btn-warning" onclick="printCAM()"><i class="fas fa-print me-2"></i>Stampa</button>
+                        <button class="btn btn-secondary" onclick="resetCAM()"><i class="fas fa-redo me-2"></i>Reset</button>
+                    </div>
+                </div>
+            </div>
+            <div id="cam-reference" class="content-section hidden">
+                <div class="alert alert-info">Consulta l'algoritmo diagnostico completo nella scheda <em>Visualizza</em>.</div>
+            </div>
+        </div>
+    </div>
+    <script src="js/delirium.js"></script>
+</body>
+</html>

--- a/gestione-sintomi/index.php
+++ b/gestione-sintomi/index.php
@@ -365,7 +365,7 @@
           </div>
 
           <!-- DELIRIUM -->
-          <div class="category-card delirium" onclick="openCategoryView('delirium')">
+          <div class="category-card delirium" onclick="window.location.href='delirium.php'">
             <div class="category-header">
               <div class="category-icon">🧩</div>
               <div class="category-info">
@@ -373,15 +373,15 @@
                 <small>2 strumenti</small>
               </div>
               <div class="category-status">
-                <span class="badge bg-warning">In Sviluppo</span>
+                <span class="badge bg-success">✅ Disponibile</span>
               </div>
             </div>
             <div class="category-description">
               Strumenti per assessment e screening del delirium
             </div>
             <div class="category-tools">
-              <span class="tool-badge">4AT</span>
-              <span class="tool-badge">CAM</span>
+              <span class="tool-badge available">4AT</span>
+              <span class="tool-badge available">CAM</span>
             </div>
           </div>
 
@@ -474,12 +474,6 @@
 
     <!-- SEZIONE DN4 -->
     <?php include __DIR__ . '/strumenti-dn4.php'; ?>
-
-    <!-- SEZIONE 4AT -->
-    <?php include __DIR__ . '/strumenti-4at.php'; ?>
-
-    <!-- SEZIONE CAM -->
-    <?php include __DIR__ . '/strumenti-cam.php'; ?>
 
     <!-- SEZIONE RASS -->
     <?php include __DIR__ . '/strumenti-rass.php'; ?>

--- a/gestione-sintomi/js/delirium.js
+++ b/gestione-sintomi/js/delirium.js
@@ -1,0 +1,220 @@
+let current4ATScores = {1: null, 2: null, 3: null, 4: null};
+let currentCAMFeatures = {1: null, 2: null, 3: null, 4: null};
+
+document.addEventListener('DOMContentLoaded', function() {
+  const today = new Date().toISOString().split('T')[0];
+  document.querySelectorAll('#4at-assessment input[type="date"], #cam-assessment input[type="date"]').forEach(inp => {
+    if (!inp.value) inp.value = today;
+  });
+});
+
+function showMainView() {
+  document.getElementById('main-view').style.display = 'block';
+  document.getElementById('4at-assessment').classList.remove('active');
+  document.getElementById('cam-assessment').classList.remove('active');
+}
+
+function show4ATAssessment(mode = 'compile') {
+  document.getElementById('main-view').style.display = 'none';
+  document.getElementById('4at-assessment').classList.add('active');
+  document.getElementById('cam-assessment').classList.remove('active');
+  switch4ATMode(mode);
+}
+
+function showCAMAssessment(mode = 'compile') {
+  document.getElementById('main-view').style.display = 'none';
+  document.getElementById('cam-assessment').classList.add('active');
+  document.getElementById('4at-assessment').classList.remove('active');
+  switchCAMMode(mode);
+}
+
+function switch4ATMode(mode) {
+  const compile = document.getElementById('4at-compile');
+  const reference = document.getElementById('4at-reference');
+  const buttons = document.querySelectorAll('#4at-assessment .mode-btn');
+  buttons.forEach(b => b.classList.remove('active'));
+  if (mode === 'compile') {
+    compile.classList.remove('hidden');
+    reference.classList.add('hidden');
+    buttons[0].classList.add('active');
+  } else {
+    compile.classList.add('hidden');
+    reference.classList.remove('hidden');
+    buttons[1].classList.add('active');
+  }
+}
+
+function select4ATAnswer(question, score, element) {
+  current4ATScores[question] = score;
+  const item = document.getElementById(`4at-q${question}`);
+  item.classList.add('completed');
+  item.querySelectorAll('.radio-option').forEach(opt => opt.classList.remove('selected'));
+  element.classList.add('selected');
+  element.querySelector('input').checked = true;
+  update4ATProgress();
+  if (isAll4ATCompleted()) calculate4ATScore();
+}
+
+function update4ATProgress() {
+  const completed = Object.values(current4ATScores).filter(s => s !== null).length;
+  const total = 4;
+  document.getElementById('4at-progress-text').textContent = `${completed}/${total} completati`;
+  document.getElementById('4at-progress-bar').style.width = `${(completed/total)*100}%`;
+}
+
+function isAll4ATCompleted() {
+  return Object.values(current4ATScores).every(s => s !== null);
+}
+
+function calculate4ATScore() {
+  const total = Object.values(current4ATScores).reduce((a,b) => a + b, 0);
+  let interpretation, description;
+  if (total === 0) {
+    interpretation = 'Delirium improbabile';
+    description = 'Il punteggio suggerisce che il delirium è improbabile.';
+  } else if (total >= 1 && total <= 3) {
+    interpretation = 'Possibile deterioramento cognitivo';
+    description = 'Valutazione più approfondita consigliata.';
+  } else {
+    interpretation = 'Possibile delirium';
+    description = 'Valutazione clinica urgente raccomandata.';
+  }
+  document.getElementById('4at-score').textContent = total;
+  document.getElementById('4at-interpretation').textContent = interpretation;
+  document.getElementById('4at-description').textContent = description;
+  document.getElementById('4at-results').classList.remove('hidden');
+}
+
+function reset4AT() {
+  current4ATScores = {1: null, 2: null, 3: null, 4: null};
+  document.querySelectorAll('#4at-assessment input[type="radio"]').forEach(i => i.checked = false);
+  document.querySelectorAll('#4at-assessment .radio-option').forEach(o => o.classList.remove('selected'));
+  document.querySelectorAll('#4at-assessment .question-item').forEach(i => i.classList.remove('completed'));
+  document.querySelectorAll('#4at-assessment input[type="text"]').forEach(i => i.value = '');
+  const today = new Date().toISOString().split('T')[0];
+  document.querySelectorAll('#4at-assessment input[type="date"]').forEach(i => i.value = today);
+  update4ATProgress();
+  document.getElementById('4at-results').classList.add('hidden');
+}
+
+function print4AT() {
+  const name = document.getElementById('4at-patient-name').value || '';
+  const birth = document.getElementById('4at-patient-birth').value || '';
+  const date = document.getElementById('4at-date').value || '';
+  const total = document.getElementById('4at-score').textContent;
+  const interpretation = document.getElementById('4at-interpretation').textContent;
+  const description = document.getElementById('4at-description').textContent;
+  const labels = {
+    1: 'Allerta',
+    2: 'Test di Attenzione',
+    3: 'Attenzione (alternativo)',
+    4: 'Cambiamento Acuto'
+  };
+  const w = window.open('', '_blank');
+  w.document.write('<html><head><title>4AT - Stampa</title><style>body{font-family:Arial,sans-serif;margin:20px;}h2{text-align:center;}table{width:100%;border-collapse:collapse;margin-top:20px;}td,th{border:1px solid #000;padding:6px;}p{margin:4px 0;}</style></head><body>');
+  w.document.write('<h2>4AT - 4 \u201CA\u2019s Test</h2>');
+  w.document.write(`<p><strong>Paziente:</strong> ${name}<br><strong>Nascita:</strong> ${birth}<br><strong>Data valutazione:</strong> ${date}</p>`);
+  w.document.write('<table><thead><tr><th>Parametro</th><th>Punteggio</th></tr></thead><tbody>');
+  for (let i = 1; i <= 4; i++) {
+    w.document.write(`<tr><td>${labels[i]}</td><td>${current4ATScores[i] ?? ''}</td></tr>`);
+  }
+  w.document.write(`</tbody></table><p><strong>Punteggio Totale:</strong> ${total}</p>`);
+  w.document.write(`<p><strong>Interpretazione:</strong> ${interpretation}</p><p>${description}</p>`);
+  w.document.write('</body></html>');
+  w.document.close();
+  w.print();
+}
+
+function switchCAMMode(mode) {
+  const compile = document.getElementById('cam-compile');
+  const reference = document.getElementById('cam-reference');
+  const buttons = document.querySelectorAll('#cam-assessment .mode-btn');
+  buttons.forEach(b => b.classList.remove('active'));
+  if (mode === 'compile') {
+    compile.classList.remove('hidden');
+    reference.classList.add('hidden');
+    buttons[0].classList.add('active');
+  } else {
+    compile.classList.add('hidden');
+    reference.classList.remove('hidden');
+    buttons[1].classList.add('active');
+  }
+}
+
+function selectCAMAnswer(feature, present, element) {
+  currentCAMFeatures[feature] = present;
+  const item = document.getElementById(`cam-f${feature}`);
+  item.classList.add('completed');
+  item.querySelectorAll('.radio-option').forEach(opt => opt.classList.remove('selected'));
+  element.classList.add('selected');
+  element.querySelector('input').checked = true;
+  updateCAMProgress();
+  if (isAllCAMCompleted()) calculateCAMDiagnosis();
+}
+
+function updateCAMProgress() {
+  const completed = Object.values(currentCAMFeatures).filter(v => v !== null).length;
+  document.getElementById('cam-progress-text').textContent = `${completed}/4 completati`;
+  document.getElementById('cam-progress-bar').style.width = `${(completed/4)*100}%`;
+}
+
+function isAllCAMCompleted() {
+  return Object.values(currentCAMFeatures).every(v => v !== null);
+}
+
+function calculateCAMDiagnosis() {
+  const f1 = currentCAMFeatures[1];
+  const f2 = currentCAMFeatures[2];
+  const f3 = currentCAMFeatures[3];
+  const f4 = currentCAMFeatures[4];
+  const deliriumPresent = f1 && f2 && (f3 || f4);
+  if (deliriumPresent) {
+    document.getElementById('cam-diagnosis').textContent = 'DELIRIUM PRESENTE';
+    document.getElementById('cam-interpretation').textContent = 'Diagnosi Positiva';
+    document.getElementById('cam-description').textContent = 'L\'algoritmo CAM indica la presenza di delirium.';
+  } else {
+    document.getElementById('cam-diagnosis').textContent = 'DELIRIUM ASSENTE';
+    document.getElementById('cam-interpretation').textContent = 'Diagnosi Negativa';
+    document.getElementById('cam-description').textContent = 'L\'algoritmo CAM non soddisfa i criteri per delirium.';
+  }
+  document.getElementById('cam-results').classList.remove('hidden');
+}
+
+function resetCAM() {
+  currentCAMFeatures = {1: null, 2: null, 3: null, 4: null};
+  document.querySelectorAll('#cam-assessment input[type="radio"]').forEach(i => i.checked = false);
+  document.querySelectorAll('#cam-assessment .radio-option').forEach(o => o.classList.remove('selected'));
+  document.querySelectorAll('#cam-assessment .question-item').forEach(i => i.classList.remove('completed'));
+  updateCAMProgress();
+  document.getElementById('cam-results').classList.add('hidden');
+}
+
+function printCAM() {
+  const name = document.getElementById('cam-patient-name').value || '';
+  const birth = document.getElementById('cam-patient-birth').value || '';
+  const date = document.getElementById('cam-date').value || '';
+  const diagnosis = document.getElementById('cam-diagnosis').textContent;
+  const interpretation = document.getElementById('cam-interpretation').textContent;
+  const description = document.getElementById('cam-description').textContent;
+  const labels = {
+    1: 'Esordio acuto e corso fluttuante',
+    2: 'Disattenzione',
+    3: 'Pensiero disorganizzato',
+    4: 'Livello di coscienza alterato'
+  };
+  const w = window.open('', '_blank');
+  w.document.write('<html><head><title>CAM - Stampa</title><style>body{font-family:Arial,sans-serif;margin:20px;}h2{text-align:center;}table{width:100%;border-collapse:collapse;margin-top:20px;}td,th{border:1px solid #000;padding:6px;}p{margin:4px 0;}</style></head><body>');
+  w.document.write('<h2>CAM - Confusion Assessment Method</h2>');
+  w.document.write(`<p><strong>Paziente:</strong> ${name}<br><strong>Nascita:</strong> ${birth}<br><strong>Data valutazione:</strong> ${date}</p>`);
+  w.document.write('<table><thead><tr><th>Caratteristica</th><th>Presente</th></tr></thead><tbody>');
+  for (let i = 1; i <= 4; i++) {
+    const val = currentCAMFeatures[i] ? 'S\u00ec' : 'No';
+    w.document.write(`<tr><td>${labels[i]}</td><td>${val}</td></tr>`);
+  }
+  w.document.write('</tbody></table>');
+  w.document.write(`<p><strong>Risultato:</strong> ${diagnosis}</p>`);
+  w.document.write(`<p><strong>Interpretazione:</strong> ${interpretation}</p><p>${description}</p>`);
+  w.document.write('</body></html>');
+  w.document.close();
+  w.print();
+}

--- a/gestione-sintomi/js/strumenti-valutazione.js
+++ b/gestione-sintomi/js/strumenti-valutazione.js
@@ -128,15 +128,6 @@ function loadCategoryContent(categoryName) {
         { name: 'ESAS', subtitle: 'Edmonton Symptom Assessment System', description: 'Sistema di valutazione rapida dei sintomi più comuni in cure palliative.', available: true, action: 'openESASCompile()' }
       ]
     },
-    'delirium': {
-      title: 'Assessment Delirium',
-      icon: '🧩',
-      description: 'Strumenti per assessment e screening del delirium',
-      tools: [
-        { name: '4AT', subtitle: "4 'A's Test", description: 'Strumento rapido di screening per delirium e deterioramento cognitivo.', available: false },
-        { name: 'CAM', subtitle: 'Confusion Assessment Method', description: 'Metodo standard per la diagnosi di delirium validato in ambito clinico.', available: false }
-      ]
-    },
     'sedazione': {
       title: 'Scale di Sedazione',
       icon: '💤',

--- a/gestione-sintomi/strumenti-4at.php
+++ b/gestione-sintomi/strumenti-4at.php
@@ -1,10 +1,98 @@
 <?php
-// placeholder per 4AT
 ?>
-<section id="4at-home" class="p-4" style="display:none;">
-  <div class="bg-white p-4 rounded shadow-sm">
-    <h5 class="mb-3"><i class="fas fa-puzzle-piece me-2"></i>4AT</h5>
-    <p>Sezione in costruzione.</p>
-  </div>
-</section>
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>4AT - Scala di Riferimento</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.1/css/all.min.css" rel="stylesheet">
+    <link href="css/delirium.css" rel="stylesheet">
+    <style>
+        .scale-table{width:100%;border-collapse:collapse;margin:1.5rem 0;border-radius:10px;overflow:hidden;box-shadow:0 3px 15px rgba(0,0,0,0.1);} 
+        .scale-table th{background:var(--delirium-primary);color:#fff;padding:1rem;font-weight:600;text-align:left;} 
+        .scale-table td{padding:0.8rem 1rem;border-bottom:1px solid #e9ecef;} 
+        .scale-table tbody tr:nth-child(even){background:#f8f9fa;} 
+        .interpretation-box{background:linear-gradient(135deg,#f8f9fa,#e9ecef);border-radius:12px;padding:1.5rem;border:2px solid var(--delirium-light);} 
+        .glossary-term{background:#fff;border:2px solid #e9ecef;border-radius:10px;padding:1.5rem;margin:1rem 0;} 
+    </style>
+</head>
+<body>
+<div class="container my-4">
+    <div class="mb-3">
+        <a href="index.php" class="btn btn-success me-2"><i class="fas fa-arrow-left me-2"></i>Torna alle Categorie</a>
+        <a href="delirium.php" class="btn btn-outline-secondary" style="border-color:#6f42c1;color:#6f42c1;"><i class="fas fa-arrow-left me-2"></i>Torna a Delirium</a>
+    </div>
 
+    <h1 class="mb-4">📊 4AT - Scala di Riferimento Completa</h1>
+    <table class="scale-table">
+        <thead>
+            <tr><th>Parametro</th><th>Punteggio</th><th>Descrizione</th></tr>
+        </thead>
+        <tbody>
+            <tr><td rowspan="3"><strong>[1] Vigilanza</strong><br><em>Valutare lo stato di vigilanza del paziente</em></td><td style="background:#d4edda;font-weight:bold;">0</td><td>Normale, completamente vigile</td></tr>
+            <tr><td style="background:#d4edda;font-weight:bold;">0</td><td>Moderata sonnolenza &lt;10 sec dopo il risveglio</td></tr>
+            <tr><td style="background:#f8d7da;font-weight:bold;">4</td><td>Iperattivo, agitato o marcatamente soporoso</td></tr>
+            <tr><td rowspan="3"><strong>[2] AMT4</strong><br><em>Età, data di nascita, luogo, anno corrente</em></td><td style="background:#d4edda;font-weight:bold;">0</td><td>Nessun errore</td></tr>
+            <tr><td style="background:#fff3cd;font-weight:bold;">1</td><td>1 errore</td></tr>
+            <tr><td style="background:#f8d7da;font-weight:bold;">2</td><td>2+ errori / non testabile</td></tr>
+            <tr><td rowspan="3"><strong>[3] Attenzione</strong><br><em>Test lettere o mesi all'indietro</em></td><td style="background:#d4edda;font-weight:bold;">0</td><td>7 o più mesi corretti</td></tr>
+            <tr><td style="background:#fff3cd;font-weight:bold;">1</td><td>Meno di 7 mesi / rifiuta di iniziare</td></tr>
+            <tr><td style="background:#f8d7da;font-weight:bold;">2</td><td>Non testabile</td></tr>
+            <tr><td rowspan="2"><strong>[4] Cambiamento acuto o fluttuante</strong></td><td style="background:#d4edda;font-weight:bold;">0</td><td>No</td></tr>
+            <tr><td style="background:#f8d7da;font-weight:bold;">4</td><td>Sì, cambiamento nelle ultime 2 settimane e ancora presente</td></tr>
+        </tbody>
+    </table>
+
+    <div class="interpretation-box mb-4">
+        <h3 class="h5 mb-3">📈 Interpretazione Punteggi</h3>
+        <div class="alert alert-success"><strong>&ge;4:</strong> Possibile delirium ± deficit cognitivo</div>
+        <div class="alert alert-warning"><strong>1-3:</strong> Possibile deterioramento cognitivo, richiede valutazione</div>
+        <div class="alert alert-info"><strong>0:</strong> Delirium improbabile</div>
+    </div>
+
+    <h2 class="mt-5">📚 Glossario di Utilizzo</h2>
+    <div class="glossary-term">
+        <h4>Vigilanza (Alertness)</h4>
+        <p>Livello di coscienza e reattività del paziente agli stimoli.</p>
+    </div>
+    <div class="glossary-term">
+        <h4>AMT4</h4>
+        <p>Breve test cognitivo: età, data di nascita, luogo, anno corrente.</p>
+    </div>
+    <div class="glossary-term">
+        <h4>Test di Attenzione</h4>
+        <p>Sequenza di lettere (SAVEAHAART) o mesi dell'anno all'indietro.</p>
+    </div>
+    <div class="glossary-term">
+        <h4>Cambiamento Acuto o Fluttuante</h4>
+        <p>Variazioni cognitive o comportamentali nelle ultime 2 settimane.</p>
+    </div>
+
+    <div class="alert alert-warning mt-4">
+        <strong>Limitazioni:</strong>
+        <ul class="mb-0"><li>Strumento di screening, non diagnostico</li><li>Adattare per barriere linguistiche o sensoriali</li><li>Pazienti non testabili: assegnare punteggi massimi</li></ul>
+    </div>
+
+    <div class="text-center mt-4">
+        <button class="btn btn-outline-primary" onclick="print4ATTemplate()"><i class="fas fa-print me-2"></i>Stampa Template Vuoto</button>
+    </div>
+</div>
+<script>
+function print4ATTemplate(){
+    const w=window.open('', '_blank');
+    w.document.write(`<!DOCTYPE html><html><head><title>4AT - Template Vuoto</title><style>body{font-family:Arial,sans-serif;margin:2cm;font-size:12px;line-height:1.4;}h1{text-align:center;} .section{margin-top:1.5cm;} .checkbox{display:inline-block;width:18px;height:18px;border:2px solid #000;margin-right:8px;} @page{margin:1.5cm;}</style></head><body>`);
+    w.document.write('<h1>4AT - 4 \u201cA\u2019s Test</h1><p>Paziente: ____________ Data: ____________</p>');
+    w.document.write('<div class="section"><strong>1. Vigilanza</strong><br><span class="checkbox"></span>0 Normale<br><span class="checkbox"></span>0 Moderata sonnolenza<br><span class="checkbox"></span>4 Alterata</div>');
+    w.document.write('<div class="section"><strong>2. AMT4</strong><br><span class="checkbox"></span>0 Nessun errore<br><span class="checkbox"></span>1 1 errore<br><span class="checkbox"></span>2 2+ errori / non testabile</div>');
+    w.document.write('<div class="section"><strong>3. Attenzione</strong><br><span class="checkbox"></span>0 7+ mesi corretti<br><span class="checkbox"></span>1 &lt;7 mesi / rifiuta<br><span class="checkbox"></span>2 Non testabile</div>');
+    w.document.write('<div class="section"><strong>4. Cambiamento acuto</strong><br><span class="checkbox"></span>0 No<br><span class="checkbox"></span>4 Sì</div>');
+    w.document.write('<div class="section"><strong>Punteggio Totale: ___/12</strong><br>0: delirium improbabile | 1-3: possibile deterioramento | ≥4: possibile delirium</div>');
+    w.document.write('</body></html>');
+    w.document.close();
+    w.print();
+}
+</script>
+</body>
+</html>

--- a/gestione-sintomi/strumenti-cam.php
+++ b/gestione-sintomi/strumenti-cam.php
@@ -1,10 +1,268 @@
 <?php
-// placeholder per CAM
 ?>
-<section id="cam-home" class="p-4" style="display:none;">
-  <div class="bg-white p-4 rounded shadow-sm">
-    <h5 class="mb-3"><i class="fas fa-puzzle-piece me-2"></i>CAM</h5>
-    <p>Sezione in costruzione.</p>
-  </div>
-</section>
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CAM - Algoritmo Diagnostico</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.1/css/all.min.css" rel="stylesheet">
+    <link href="css/delirium.css" rel="stylesheet">
+    <style>
+        .algorithm-box{background:linear-gradient(135deg,#e8f5e8,#d4edda);border:3px solid var(--success-color);border-radius:15px;padding:2rem;margin:2rem 0;text-align:center;}
+        .scale-table{width:100%;margin:2rem 0;border-collapse:collapse;border-radius:15px;overflow:hidden;box-shadow:0 5px 20px rgba(0,0,0,0.1);}
+        .scale-table th{background:var(--delirium-primary);color:#fff;padding:1.5rem;font-weight:700;text-align:left;}
+        .scale-table td{padding:1.2rem 1.5rem;border-bottom:1px solid #e9ecef;}
+        .scale-table tbody tr:nth-child(even){background:#f8f9fa;}
+        .scale-table tbody tr:hover{background:var(--delirium-light);}
+        .interpretation-box{background:linear-gradient(135deg,#f8f9fa,#e9ecef);border-radius:12px;padding:1.5rem;margin:1.5rem 0;border:2px solid var(--delirium-light);}
+    </style>
+</head>
+<body>
+<div class="container my-4">
+    <div class="mb-3">
+        <a href="index.php" class="btn btn-success me-2"><i class="fas fa-arrow-left me-2"></i>Torna alle Categorie</a>
+        <a href="delirium.php" class="btn btn-outline-secondary" style="border-color:#6f42c1;color:#6f42c1;"><i class="fas fa-arrow-left me-2"></i>Torna a Delirium</a>
+    </div>
 
+    <h1 class="mb-4">🔍 CAM - Scala di Riferimento e Algoritmo Diagnostico</h1>
+
+    <div class="algorithm-box">
+        <h2>🎯 Algoritmo Diagnostico CAM</h2>
+        <p style="font-size:1.2rem;margin:1rem 0;"><strong>DELIRIUM PRESENTE se:</strong><br>
+            <span style="background:#fff;padding:0.5rem;border-radius:5px;display:inline-block;margin:0.5rem;">(Caratteristica 1 <strong>E</strong> Caratteristica 2) <strong>E</strong> (Caratteristica 3 <strong>O</strong> Caratteristica 4)</span>
+        </p>
+    </div>
+
+    <table class="scale-table">
+        <thead>
+            <tr>
+                <th style="width:30%">Caratteristica</th>
+                <th style="width:15%">Valutazione</th>
+                <th style="width:55%">Esempi di Indagine Clinica</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td rowspan="2"><strong>1. Insorgenza acuta e andamento fluttuante</strong><br><em>C'è stato un cambiamento acuto nello stato mentale del paziente rispetto alla sua situazione di base?</em></td>
+                <td style="background:#f8d7da;font-weight:bold;">PRESENTE</td>
+                <td><strong>Domande da porre ai familiari/caregiver:</strong><br>• "Come era il paziente una settimana fa rispetto ad oggi?"<br>• "Ha notato cambiamenti nel comportamento nelle ultime 24-48 ore?"<br>• "I sintomi vanno e vengono durante il giorno?"<br>• "C'è stata confusione che prima non c'era?"</td>
+            </tr>
+            <tr>
+                <td style="background:#d4edda;font-weight:bold;">ASSENTE</td>
+                <td>Nessun cambiamento significativo, comportamento stabile rispetto al baseline</td>
+            </tr>
+
+            <tr>
+                <td rowspan="2"><strong>2. Perdita dell'attenzione</strong><br><em>Il paziente presenta difficoltà nel concentrare la sua attenzione, per esempio è facilmente distraibile, non riesce a mantenere il filo del discorso ecc.?</em></td>
+                <td style="background:#f8d7da;font-weight:bold;">PRESENTE</td>
+                <td><strong>Osservazioni cliniche:</strong><br>• Si distrae facilmente durante la conversazione<br>• Difficoltà a seguire comandi semplici<br>• Perde il filo del discorso<br>• Non riesce a mantenere l'attenzione su una task<br><strong>Test:</strong> Può usare test delle lettere (4AT) o digits span</td>
+            </tr>
+            <tr>
+                <td style="background:#d4edda;font-weight:bold;">ASSENTE</td>
+                <td>Attenzione normale, riesce a seguire la conversazione e i comandi</td>
+            </tr>
+
+            <tr>
+                <td rowspan="2"><strong>3. Disorganizzazione del pensiero</strong><br><em>Il pensiero del paziente è disorganizzato e incoerente, passa da un argomento all'altro senza filo logico, in modo imprevedibile?</em></td>
+                <td style="background:#f8d7da;font-weight:bold;">PRESENTE</td>
+                <td><strong>Evidenze di pensiero disorganizzato:</strong><br>• Conversazione incoerente o sconnessa<br>• Flusso di idee poco chiaro o illogico<br>• Passa da un argomento all'altro senza logica<br>• Risposte inappropriate alle domande<br>• Discorso confuso o frammentario</td>
+            </tr>
+            <tr>
+                <td style="background:#d4edda;font-weight:bold;">ASSENTE</td>
+                <td>Pensiero organizzato e coerente, conversazione logica</td>
+            </tr>
+
+            <tr>
+                <td rowspan="2"><strong>4. Alterato livello di coscienza</strong><br><em>0=vigile 1=iperallerta, letargia, stupor, coma</em></td>
+                <td style="background:#f8d7da;font-weight:bold;">ALTERATO</td>
+                <td><strong>Livelli di coscienza alterati:</strong><br>• <strong>Iperallerta:</strong> Ipervigilante, facilmente allarmabile<br>• <strong>Letargia:</strong> Soporoso ma risvegliabile alla voce<br>• <strong>Stupor:</strong> Difficile da risvegliare, risponde poco<br>• <strong>Coma:</strong> Non responsivo agli stimoli verbali</td>
+            </tr>
+            <tr>
+                <td style="background:#d4edda;font-weight:bold;">NORMALE</td>
+                <td><strong>Vigile:</strong> Livello di coscienza normale, appropriatamente allerta</td>
+            </tr>
+        </tbody>
+    </table>
+
+    <div class="interpretation-box">
+        <h3>📊 Interpretazione Algoritmo CAM</h3>
+        <div class="row" style="display:flex;gap:2rem;margin-top:1.5rem;">
+            <div style="flex:1;">
+                <div class="alert alert-success">
+                    <h4>✅ DELIRIUM PRESENTE</h4>
+                    <p><strong>Se sono soddisfatti:</strong></p>
+                    <ul style="margin:0.5rem 0;">
+                        <li>Caratteristica 1: PRESENTE</li>
+                        <li>Caratteristica 2: PRESENTE</li>
+                        <li>Caratteristica 3 O 4: PRESENTE</li>
+                    </ul>
+                </div>
+            </div>
+            <div style="flex:1;">
+                <div class="alert alert-warning" style="background:#f8d7da;border-color:#dc3545;">
+                    <h4>❌ DELIRIUM ASSENTE</h4>
+                    <p><strong>Se manca anche solo uno di:</strong></p>
+                    <ul style="margin:0.5rem 0;">
+                        <li>Caratteristica 1</li>
+                        <li>Caratteristica 2</li>
+                        <li>Entrambe Caratteristiche 3 e 4</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="alert alert-info">
+        <h4>📋 Performance Diagnostica CAM</h4>
+        <div style="display:flex;gap:2rem;margin-top:1rem;">
+            <div><strong>Sensibilità:</strong> 94-100%</div>
+            <div><strong>Specificità:</strong> 90-95%</div>
+            <div><strong>Tempo di somministrazione:</strong> 5-10 minuti</div>
+        </div>
+    </div>
+
+    <div class="alert alert-warning">
+        <h4>⚠️ Note Importanti per la Valutazione</h4>
+        <ul>
+            <li><strong>Caratteristica 1:</strong> Richiede sempre informazioni da fonti esterne (famiglia, caregiver, documentazione)</li>
+            <li><strong>Caratteristiche 2-4:</strong> Valutabili attraverso osservazione diretta durante la visita</li>
+            <li><strong>Timing:</strong> Il delirium può fluttuare, considerare rivalutazioni multiple</li>
+            <li><strong>Sottotipi:</strong> Considerare delirium ipoattivo (meno evidente ma presente)</li>
+        </ul>
+    </div>
+
+    <div class="text-center mt-4">
+        <button class="btn btn-outline-primary" onclick="printCAMTemplate()"><i class="fas fa-print me-2"></i>Stampa Template Vuoto</button>
+    </div>
+</div>
+<script>
+function printCAMTemplate() {
+    const templateWindow = window.open('', '_blank', 'width=800,height=1200');
+    templateWindow.document.write(`
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <title>CAM - Template Vuoto</title>
+            <style>
+                @page { margin: 1.5cm; size: A4; }
+                body {
+                    font-family: 'Courier New', monospace;
+                    margin: 0;
+                    font-size: 11px;
+                    line-height: 1.3;
+                }
+                .header {
+                    text-align: center;
+                    margin-bottom: 1cm;
+                    border: 2px solid #000;
+                    padding: 0.5rem;
+                }
+                .section {
+                    border: 1px solid #000;
+                    margin-bottom: 0.8cm;
+                    padding: 0.8rem;
+                }
+                .algorithm {
+                    border: 3px double #000;
+                    margin: 1cm 0;
+                    padding: 1rem;
+                    text-align: center;
+                    background: #f5f5f5;
+                }
+                .checkbox {
+                    display: inline-block;
+                    width: 12px;
+                    height: 12px;
+                    border: 1.5px solid #000;
+                    margin-right: 6px;
+                    vertical-align: middle;
+                }
+                .line {
+                    border-bottom: 1px solid #000;
+                    display: inline-block;
+                    min-width: 150px;
+                    margin: 0 3px;
+                }
+                h2, h3 { margin: 0.3rem 0; }
+                .actions {
+                    border: 1px solid #000;
+                    padding: 0.8rem;
+                    margin-top: 0.5cm;
+                }
+            </style>
+        </head>
+        <body>
+            <div class="header">
+                <h2>CAM - CONFUSION ASSESSMENT METHOD</h2>
+                <h3>Algoritmo Diagnostico per Delirium</h3>
+                <p>Nome: <span class="line"></span> Data: <span class="line"></span> Ora: <span class="line"></span></p>
+                <p>Età: <span class="line"></span> Reparto: <span class="line"></span> Valutatore: <span class="line"></span></p>
+            </div>
+
+            <div class="section">
+                <h3>CARATTERISTICA 1: INSORGENZA ACUTA E ANDAMENTO FLUTTUANTE</h3>
+                <p>C'è stato un cambiamento acuto nello stato mentale rispetto alla baseline?</p>
+                <p>Fonti: <span class="checkbox"></span>Familiari <span class="checkbox"></span>Caregiver <span class="checkbox"></span>Documentazione <span class="checkbox"></span>Staff</p>
+                <p><span class="checkbox"></span> ASSENTE <span class="checkbox"></span> PRESENTE</p>
+                <p>Note: <span class="line" style="min-width: 400px;"></span></p>
+            </div>
+
+            <div class="section">
+                <h3>CARATTERISTICA 2: PERDITA DELL'ATTENZIONE</h3>
+                <p>Difficoltà nel concentrare l'attenzione? Facilmente distraibile?</p>
+                <p><span class="checkbox"></span> ASSENTE <span class="checkbox"></span> PRESENTE</p>
+                <p>Note: <span class="line" style="min-width: 400px;"></span></p>
+            </div>
+
+            <div class="section">
+                <h3>CARATTERISTICA 3: DISORGANIZZAZIONE DEL PENSIERO</h3>
+                <p>Pensiero disorganizzato? Passa da argomento ad argomento senza logica?</p>
+                <p><span class="checkbox"></span> ASSENTE <span class="checkbox"></span> PRESENTE</p>
+                <p>Note: <span class="line" style="min-width: 400px;"></span></p>
+            </div>
+
+            <div class="section">
+                <h3>CARATTERISTICA 4: ALTERATO LIVELLO DI COSCIENZA</h3>
+                <p>Livello di coscienza diverso da "normale/allerta"?</p>
+                <p><span class="checkbox"></span> NORMALE (vigile) <span class="checkbox"></span> ALTERATO</p>
+                <p>Specificare: <span class="line" style="min-width: 300px;"></span></p>
+            </div>
+
+            <div class="algorithm">
+                <h3>ALGORITMO DIAGNOSTICO CAM</h3>
+                <p><strong>(Caratteristica 1 E Caratteristica 2) E (Caratteristica 3 O Caratteristica 4)</strong></p>
+                <br>
+                <p>Caratteristica 1: <span class="checkbox"></span>Presente <span class="checkbox"></span>Assente</p>
+                <p>Caratteristica 2: <span class="checkbox"></span>Presente <span class="checkbox"></span>Assente</p>
+                <p>Caratteristica 3: <span class="checkbox"></span>Presente <span class="checkbox"></span>Assente</p>
+                <p>Caratteristica 4: <span class="checkbox"></span>Presente <span class="checkbox"></span>Assente</p>
+                <br>
+                <h3>RISULTATO:</h3>
+                <p><span class="checkbox"></span> DELIRIUM PRESENTE <span class="checkbox"></span> DELIRIUM ASSENTE</p>
+            </div>
+
+            <div class="actions">
+                <h3>AZIONI SUCCESSIVE (se delirium presente):</h3>
+                <p><span class="checkbox"></span>Identificare cause scatenanti <span class="checkbox"></span>Revisione farmaci</p>
+                <p><span class="checkbox"></span>Interventi non farmacologici <span class="checkbox"></span>Monitoraggio frequente</p>
+                <p>Prossima rivalutazione: <span class="line"></span></p>
+                <p>Note: <span class="line" style="min-width: 400px;"></span></p>
+            </div>
+
+            <div style="margin-top: 1cm; border-top: 1px solid #000; padding-top: 0.5rem;">
+                <p>Valutatore: <span class="line"></span> Firma: <span class="line"></span> Data/Ora: <span class="line"></span></p>
+            </div>
+        </body>
+        </html>
+    `);
+    templateWindow.document.close();
+    setTimeout(() => {
+        templateWindow.print();
+        templateWindow.close();
+    }, 250);
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- collegati i pulsanti "Visualizza" alle nuove pagine di riferimento per 4AT e CAM
- aggiunta pagina 4AT con tabella dettagliata, glossario e stampa del template
- ampliata pagina CAM con tabella delle caratteristiche, interpretazione e template di stampa A4
- aggiunto stile di base comune per rendere uniformi le pagine di riferimento

## Testing
- `php -l gestione-sintomi/delirium.php`
- `php -l gestione-sintomi/strumenti-4at.php`
- `php -l gestione-sintomi/strumenti-cam.php`


------
https://chatgpt.com/codex/tasks/task_e_689d6ede2dac83288726d9e21db7fcab