### PR TITLE
Corregge ricerca strumenti di valutazione

### DIFF
--- a/gestione-sintomi/js/strumenti-valutazione.js
+++ b/gestione-sintomi/js/strumenti-valutazione.js
@@ -376,17 +376,28 @@ function showSection(sectionId) {
 function initStrumentiValutazione() {
   const searchInput = document.getElementById('searchCategories');
   if (searchInput) {
-    searchInput.addEventListener('input', function(e) {
-      const term = e.target.value.toLowerCase();
-      document.querySelectorAll('.category-card').forEach(card => {
-        const title = card.querySelector('h5').textContent.toLowerCase();
-        const descEl = card.querySelector('.category-description');
-        const desc = descEl ? descEl.textContent.toLowerCase() : '';
-        const tools = Array.from(card.querySelectorAll('.tool-badge')).map(b => b.textContent.toLowerCase()).join(' ');
-        const match = title.includes(term) || desc.includes(term) || tools.includes(term);
-        card.style.display = (match || term === '') ? 'block' : 'none';
-      });
-    });
+  searchInput.addEventListener('input', function(e) {
+  const term = e.target.value.toLowerCase();
+  document.querySelectorAll('.category-card').forEach(card => {
+    // 🔧 FIX: Controllo sicuro per il titolo
+    const titleEl = card.querySelector('h5');
+    const title = titleEl ? titleEl.textContent.toLowerCase() : '';
+    
+    // ✅ Questa riga era già corretta
+    const descEl = card.querySelector('.category-description');
+    const desc = descEl ? descEl.textContent.toLowerCase() : '';
+    
+    // 🔧 FIX: Controllo sicuro per i tool badges
+    const toolBadges = card.querySelectorAll('.tool-badge');
+    const tools = toolBadges.length > 0 ? 
+      Array.from(toolBadges)
+        .map(b => b.textContent ? b.textContent.toLowerCase() : '')
+        .join(' ') : '';
+    
+    const match = title.includes(term) || desc.includes(term) || tools.includes(term);
+    card.style.display = (match || term === '') ? 'block' : 'none';
+  });
+});
   }
 
   const link = document.querySelector('[data-target="strumenti-valutazione-home"]');

--- a/gestione-sintomi/js/strumenti-valutazione.js
+++ b/gestione-sintomi/js/strumenti-valutazione.js
@@ -373,14 +373,15 @@ function showSection(sectionId) {
   if (activeLink) activeLink.classList.add('active');
 }
 
-document.addEventListener('DOMContentLoaded', function() {
+function initStrumentiValutazione() {
   const searchInput = document.getElementById('searchCategories');
   if (searchInput) {
     searchInput.addEventListener('input', function(e) {
       const term = e.target.value.toLowerCase();
       document.querySelectorAll('.category-card').forEach(card => {
         const title = card.querySelector('h5').textContent.toLowerCase();
-        const desc = card.querySelector('.category-description').textContent.toLowerCase();
+        const descEl = card.querySelector('.category-description');
+        const desc = descEl ? descEl.textContent.toLowerCase() : '';
         const tools = Array.from(card.querySelectorAll('.tool-badge')).map(b => b.textContent.toLowerCase()).join(' ');
         const match = title.includes(term) || desc.includes(term) || tools.includes(term);
         card.style.display = (match || term === '') ? 'block' : 'none';
@@ -410,7 +411,13 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   console.log('✅ Strumenti di Valutazione inizializzati correttamente');
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initStrumentiValutazione);
+} else {
+  initStrumentiValutazione();
+}
 
 function animateStats() {
   const statNumbers = document.querySelectorAll('.stat-number');


### PR DESCRIPTION
## Sintesi
- inizializza correttamente gli script degli strumenti di valutazione
- abilita la ricerca tra le categorie anche dopo il caricamento della pagina

## Verifica
- `php -l gestione-sintomi/index.php`


------
https://chatgpt.com/codex/tasks/task_e_689e38cb9870832896e1b327b884e377